### PR TITLE
Add Watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ The `tracker` binary is responsible for tracking the actual consumption data of 
 
 The `server` binary provides a web interface that can be used for registering a parachain for consumption tracking, as well as for querying all the consumption data.
 
+### Watchdog 🐕
+
+WebSocket connections can be closed due to underlying networking issues. In such cases, the tracking of parachain data would stop. For this reason, a script called 'watchdog' is introduced to ensure the tracker attempts to create a new connection whenever the current one is broken.
+
+```sh
+./scripts/watchdog.sh
+```
+
 ## Web API
 
 #### Registering a parachain

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+FILE_TO_WATCH="nohup.out"
+
+WS_CONNECTION_ERROR="Failed to read message: Networking or low-level protocol error: WebSocket connection error: connection closed"
+TRACKER="./target/release/tracker"
+
+restart_tracker() {
+    PIDS=$(pgrep -f "$TRACKER")
+
+    if [ -z "$PIDS" ]; then
+        echo "Process not found."
+    else
+        # Kill each process
+        for PID in $PIDS; do
+            kill -9 $PID
+        done
+
+        # start the tracker again
+        nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' &
+    fi
+}
+
+# Continuously watch the file
+tail -f "$FILE_TO_WATCH" | while read LINE
+do
+    echo "$LINE" | grep "$WS_CONNECTION_ERROR" > /dev/null
+    if [ $? = 0 ]
+    then
+       restart_tracker 
+    fi
+done


### PR DESCRIPTION
WebSocket connections can be closed due to underlying networking issues. In such cases, the tracking of parachain data would stop. For this reason, a script called 'watchdog' is introduced to ensure the tracker attempts to create a new connection whenever the current one is broken.

Closes: #16 