### PR TITLE
Extend subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,7 +3332,6 @@ version = "0.1.0"
 dependencies = [
  "log",
  "maplit",
- "parity-scale-codec",
  "polkadot-core-primitives",
  "rocket",
  "rocket_cors",
@@ -3340,8 +3339,6 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
- "sp-runtime",
- "subxt",
  "types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,8 @@ version = "0.1.0"
 dependencies = [
  "csv",
  "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
  "serde",
  "serde_json",
  "subxt",

--- a/routes/Cargo.toml
+++ b/routes/Cargo.toml
@@ -11,10 +11,7 @@ rocket = { version = "0.5.0", features=["json"] }
 rocket_cors = "0.6.0"
 serde = "1.0.193"
 serde_json = "1.0.108"
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
 polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
-parity-scale-codec = "3.6.9"
-subxt = "0.32.1"
 
 types = { path = "../types" }
 shared = { path = "../shared", features = ["test-utils"]}

--- a/routes/src/extend_subscription.rs
+++ b/routes/src/extend_subscription.rs
@@ -13,26 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-	register::polkadot::runtime_types::{
-		frame_system::pallet::Call as SystemCall, pallet_balances::pallet::Call as BalancesCall,
-		pallet_utility::pallet::Call as UtilityCall,
-	},
-	*,
-};
-use parity_scale_codec::Encode;
+
 use polkadot_core_primitives::BlockNumber;
 use rocket::{post, serde::json::Json};
 use shared::{
 	config::{config, PaymentInfo},
 	current_timestamp,
 	registry::{registered_para, registered_paras, update_registry},
-};
-use subxt::{
-	backend::rpc::{rpc_params, RpcClient},
-	blocks::Block,
-	utils::H256,
-	OnlineClient, PolkadotConfig,
 };
 use types::{ParaId, RelayChain};
 

--- a/routes/src/extend_subscription.rs
+++ b/routes/src/extend_subscription.rs
@@ -34,7 +34,7 @@ pub struct ExtendSubscriptionData {
 }
 
 /// Extend the subscription of a parachain for resource utilization tracking.
-#[post("/extend_subscription", data = "<data>")]
+#[post("/extend-subscription", data = "<data>")]
 pub async fn extend_subscription(data: Json<ExtendSubscriptionData>) -> Result<(), Error> {
 	let (relay_chain, para_id) = data.para.clone();
 

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -19,6 +19,7 @@
 //! - `/consumption`: Used to query consumption data associated with a parachain.
 //! - `/register`: Used to register a parachain for consumption tracking.
 //! - `/registry`: Used for querying all the registered parachains.
+//! - `/extend-subscription`: For extending the subscription of a parachain.
 
 use rocket::{http::Status, response::Responder, Request, Response};
 use serde::{Deserialize, Serialize};

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -75,6 +75,6 @@ impl From<String> for Error {
 }
 
 pub mod consumption;
-//pub mod extend_subscription;
+pub mod extend_subscription;
 pub mod register;
 pub mod registry;

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -63,13 +63,12 @@ impl From<String> for Error {
 			"ConsumptionDataNotFound" => Self::ConsumptionDataNotFound,
 			"InvalidData" => Self::InvalidData,
 			"PaymentRequired" => Self::PaymentRequired,
-			// TODO: fix
-			"PaymentValidationError(PaymentError::ValidationFailed)" =>
-				Self::PaymentValidationError(PaymentError::ValidationFailed),
-			"PaymentValidationError(PaymentError::Unfinalized)" =>
-				Self::PaymentValidationError(PaymentError::Unfinalized),
-			"PaymentValidationError(PaymentError::NotFound)" =>
-				Self::PaymentValidationError(PaymentError::NotFound),
+			_ if v.starts_with("PaymentValidationError(") => {
+				let payment_error =
+					v.trim_start_matches("PaymentValidationError(").trim_end_matches(')').trim();
+
+				Error::PaymentValidationError(PaymentError::from(payment_error.to_string()))
+			},
 			_ => panic!("UnknownError"),
 		}
 	}

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -28,7 +28,7 @@ const LOG_TARGET: &str = "server";
 pub enum Error {
 	/// Cannot register an already registered parachain.
 	AlreadyRegistered,
-	/// Tried to get the consumption of a parachain that is not registered.
+	/// The specified para is not registered.
 	NotRegistered,
 	/// Indicates that the consumption data for the parachain was not found.
 	///
@@ -74,5 +74,6 @@ impl From<String> for Error {
 }
 
 pub mod consumption;
+pub mod extend_subscription;
 pub mod register;
 pub mod registry;

--- a/routes/src/register.rs
+++ b/routes/src/register.rs
@@ -59,10 +59,9 @@ pub async fn register_para(registration_data: Json<RegistrationData>) -> Result<
 
 		validate_registration_payment(para.clone(), payment_info, payment_block_number)
 			.await
-			.map_err(|e| Error::PaymentValidationError(e))?;
+			.map_err(Error::PaymentValidationError)?;
 	}
 
-	// Set the `last_payment_timestamp` to now. We can't trust the user to provide a valid value ;)
 	para.last_payment_timestamp = current_timestamp();
 
 	paras.push(para);

--- a/routes/tests/extend_subscription.rs
+++ b/routes/tests/extend_subscription.rs
@@ -44,7 +44,7 @@ fn extend_subscription_works() {
 		};
 
 		let response = client
-			.post("/extend_subscription")
+			.post("/extend-subscription")
 			.header(ContentType::JSON)
 			.body(serde_json::to_string(&extend_subscription).unwrap())
 			.dispatch();
@@ -70,7 +70,7 @@ fn cannot_extend_subscription_for_unregistered() {
 		};
 
 		let response = client
-			.post("/extend_subscription")
+			.post("/extend-subscription")
 			.header(ContentType::JSON)
 			.body(serde_json::to_string(&extend_subscription).unwrap())
 			.dispatch();
@@ -92,7 +92,7 @@ fn providing_non_finalized_payment_block_number_fails() {
 		};
 
 		let response = client
-			.post("/extend_subscription")
+			.post("/extend-subscription")
 			.header(ContentType::JSON)
 			.body(serde_json::to_string(&extend_subscription).unwrap())
 			.dispatch();
@@ -118,7 +118,7 @@ fn payment_not_found_works() {
 		};
 
 		let response = client
-			.post("/extend_subscription")
+			.post("/extend-subscription")
 			.header(ContentType::JSON)
 			.body(serde_json::to_string(&extend_subscription).unwrap())
 			.dispatch();

--- a/routes/tests/extend_subscription.rs
+++ b/routes/tests/extend_subscription.rs
@@ -1,0 +1,136 @@
+// This file is part of RegionX.
+//
+// RegionX is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// RegionX is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
+
+use polkadot_core_primitives::BlockNumber;
+use rocket::{
+	http::{ContentType, Status},
+	local::blocking::{Client, LocalResponse},
+	routes,
+};
+use routes::{
+	extend_subscription::{extend_subscription, ExtendSubscriptionData},
+	Error,
+};
+use shared::{payment::PaymentError, registry::registered_para};
+use types::RelayChain::*;
+
+mod mock;
+use mock::{mock_para, MockEnvironment};
+
+const PARA_2000_PAYMENT: BlockNumber = 8624975;
+
+#[test]
+fn extend_subscription_works() {
+	MockEnvironment::new().execute_with(|| {
+		let rocket = rocket::build().mount("/", routes![extend_subscription]);
+		let client = Client::tracked(rocket).expect("valid rocket instance");
+
+		let para = mock_para(Polkadot, 2000);
+		let extend_subscription = ExtendSubscriptionData {
+			para: (para.relay_chain.clone(), para.para_id),
+			payment_block_number: PARA_2000_PAYMENT,
+		};
+
+		let response = client
+			.post("/extend_subscription")
+			.header(ContentType::JSON)
+			.body(serde_json::to_string(&extend_subscription).unwrap())
+			.dispatch();
+
+		assert_eq!(response.status(), Status::Ok);
+
+		let registered = registered_para(Polkadot, 2000).unwrap();
+		// Ensure the `last_payment_timestamp` got updated:
+		assert!(registered.last_payment_timestamp != para.last_payment_timestamp);
+	});
+}
+
+#[test]
+fn cannot_extend_subscription_for_unregistered() {
+	MockEnvironment::new().execute_with(|| {
+		let rocket = rocket::build().mount("/", routes![extend_subscription]);
+		let client = Client::tracked(rocket).expect("valid rocket instance");
+
+		let para = mock_para(Polkadot, 2001);
+		let extend_subscription = ExtendSubscriptionData {
+			para: (para.relay_chain.clone(), para.para_id),
+			payment_block_number: PARA_2000_PAYMENT,
+		};
+
+		let response = client
+			.post("/extend_subscription")
+			.header(ContentType::JSON)
+			.body(serde_json::to_string(&extend_subscription).unwrap())
+			.dispatch();
+
+		assert_eq!(parse_err_response(response), Error::NotRegistered);
+	});
+}
+
+#[test]
+fn providing_non_finalized_payment_block_number_fails() {
+	MockEnvironment::new().execute_with(|| {
+		let rocket = rocket::build().mount("/", routes![extend_subscription]);
+		let client = Client::tracked(rocket).expect("valid rocket instance");
+
+		let para = mock_para(Polkadot, 2000);
+		let extend_subscription = ExtendSubscriptionData {
+			para: (para.relay_chain.clone(), para.para_id),
+			payment_block_number: 99999999,
+		};
+
+		let response = client
+			.post("/extend_subscription")
+			.header(ContentType::JSON)
+			.body(serde_json::to_string(&extend_subscription).unwrap())
+			.dispatch();
+
+		assert_eq!(
+			parse_err_response(response),
+			Error::PaymentValidationError(PaymentError::Unfinalized)
+		);
+	});
+}
+
+#[test]
+fn payment_not_found_works() {
+	MockEnvironment::new().execute_with(|| {
+		let rocket = rocket::build().mount("/", routes![extend_subscription]);
+		let client = Client::tracked(rocket).expect("valid rocket instance");
+
+		let para = mock_para(Polkadot, 2005);
+		// We are extending the subscription for para 2005, but the payment is for para 2000.
+		let extend_subscription = ExtendSubscriptionData {
+			para: (para.relay_chain.clone(), para.para_id),
+			payment_block_number: PARA_2000_PAYMENT,
+		};
+
+		let response = client
+			.post("/extend_subscription")
+			.header(ContentType::JSON)
+			.body(serde_json::to_string(&extend_subscription).unwrap())
+			.dispatch();
+
+		assert_eq!(
+			parse_err_response(response),
+			Error::PaymentValidationError(PaymentError::NotFound)
+		);
+	});
+}
+
+fn parse_err_response<'a>(response: LocalResponse<'a>) -> Error {
+	let body = response.into_string().unwrap();
+	body.into()
+}

--- a/routes/tests/mock.rs
+++ b/routes/tests/mock.rs
@@ -16,10 +16,7 @@
 #[cfg(test)]
 use maplit::hashmap;
 use scopeguard::guard;
-use shared::{
-	consumption::write_consumption, current_timestamp, registry::update_registry,
-	reset_mock_environment,
-};
+use shared::{consumption::write_consumption, registry::update_registry, reset_mock_environment};
 use std::collections::HashMap;
 use types::{ParaId, Parachain, RelayChain, RelayChain::*, WeightConsumption};
 

--- a/routes/tests/register.rs
+++ b/routes/tests/register.rs
@@ -23,7 +23,10 @@ use routes::{
 	register::{register_para, RegistrationData},
 	Error,
 };
-use shared::registry::{registered_para, registered_paras};
+use shared::{
+	payment::PaymentError,
+	registry::{registered_para, registered_paras},
+};
 use types::RelayChain::*;
 
 mod mock;
@@ -115,7 +118,10 @@ fn providing_non_finalized_payment_block_number_fails() {
 			.body(serde_json::to_string(&registration_data).unwrap())
 			.dispatch();
 
-		assert_eq!(parse_err_response(response), Error::UnfinalizedPayment);
+		assert_eq!(
+			parse_err_response(response),
+			Error::PaymentValidationError(PaymentError::Unfinalized)
+		);
 	});
 }
 
@@ -136,7 +142,10 @@ fn payment_not_found_works() {
 			.body(serde_json::to_string(&registration_data).unwrap())
 			.dispatch();
 
-		assert_eq!(parse_err_response(response), Error::PaymentNotFound);
+		assert_eq!(
+			parse_err_response(response),
+			Error::PaymentValidationError(PaymentError::NotFound)
+		);
 	});
 }
 

--- a/routes/tests/register.rs
+++ b/routes/tests/register.rs
@@ -52,14 +52,14 @@ fn register_works() {
 
 		assert_eq!(response.status(), Status::Ok);
 
-		let response_para = registered_para(Polkadot, 2001).unwrap();
+		let registered = registered_para(Polkadot, 2001).unwrap();
 
 		// Set the `last_payment_timestamp` to the proper value.
-		para.last_payment_timestamp = response_para.last_payment_timestamp;
+		para.last_payment_timestamp = registered.last_payment_timestamp;
 
 		// Ensure the parachain is properly registered:
 		assert_eq!(registered_paras(), vec![para.clone()]);
-		assert_eq!(response_para, para);
+		assert_eq!(registered, para);
 	});
 }
 

--- a/routes/tests/registry.rs
+++ b/routes/tests/registry.rs
@@ -33,7 +33,9 @@ fn getting_registry_works() {
 		let response = client.get("/registry").dispatch();
 		assert_eq!(response.status(), Status::Ok);
 
-		let registry = parse_ok_response(response);
+		let mut registry = parse_ok_response(response);
+		registry.sort_by_key(|p| p.para_id);
+
 		assert_eq!(registry, vec![mock_para(Polkadot, 2000), mock_para(Polkadot, 2005)]);
 	});
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -15,6 +15,8 @@ toml = "0.8.8"
 serde = "1.0.193"
 serde_json = "1.0.108"
 subxt = "0.32.1"
+polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot-sdk", branch = "release-polkadot-v1.1.0" }
+parity-scale-codec = "3.6.9"
 
 types = { path = "../types" }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -18,6 +18,7 @@ use types::Timestamp;
 
 pub mod config;
 pub mod consumption;
+pub mod payment;
 pub mod registry;
 
 use crate::config::config;

--- a/shared/src/payment.rs
+++ b/shared/src/payment.rs
@@ -1,0 +1,148 @@
+// This file is part of RegionX.
+//
+// RegionX is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// RegionX is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
+
+//! File containing all the payment verification related logic.
+
+use crate::{
+	config::{config, PaymentInfo},
+	current_timestamp,
+	payment::polkadot::runtime_types::{
+		frame_system::pallet::Call as SystemCall, pallet_balances::pallet::Call as BalancesCall,
+		pallet_utility::pallet::Call as UtilityCall,
+	},
+	registry::{registered_para, registered_paras, update_registry},
+	*,
+};
+use parity_scale_codec::Encode;
+use polkadot_core_primitives::BlockNumber;
+use subxt::{
+	backend::rpc::{rpc_params, RpcClient},
+	blocks::Block,
+	utils::H256,
+	OnlineClient, PolkadotConfig,
+};
+use types::Parachain;
+
+#[subxt::subxt(runtime_metadata_path = "../artifacts/metadata.scale")]
+mod polkadot {}
+
+pub async fn validate_registration_payment(
+	para: Parachain,
+	payment_info: PaymentInfo,
+	payment_block_number: BlockNumber,
+) -> Result<(), Error> {
+	// TODO: Could this code be improved so that we don't have to instantiate both clients?
+	let rpc_client = RpcClient::from_url(&payment_info.rpc_url.clone())
+		.await
+		.map_err(|_| Error::PaymentValidationFailed)?;
+
+	let online_client = OnlineClient::<PolkadotConfig>::from_url(payment_info.rpc_url.clone())
+		.await
+		.map_err(|_| Error::PaymentValidationFailed)?;
+
+	// Ensure that the `payment_block_number` is from a finalized block.
+	let last_finalized =
+		get_last_finalized_block(rpc_client.clone(), online_client.clone()).await?;
+	if payment_block_number > last_finalized {
+		return Err(Error::UnfinalizedPayment)
+	}
+
+	let block_hash = get_block_hash(rpc_client, payment_block_number).await?;
+	let block = get_block(online_client, block_hash).await?;
+
+	ensure_contains_payment(para, payment_info, block).await
+}
+
+async fn ensure_contains_payment(
+	para: Parachain,
+	payment_info: PaymentInfo,
+	block: Block<PolkadotConfig, OnlineClient<PolkadotConfig>>,
+) -> Result<(), Error> {
+	let payment = opaque_payment_extrinsic(para, payment_info).await?;
+
+	let extrinsics = block.extrinsics().await.map_err(|_| Error::PaymentValidationFailed)?;
+	let extrinsics: Vec<Vec<u8>> = extrinsics
+		.iter()
+		.filter_map(|ext| {
+			ext.as_ref().ok().and_then(|e| e.as_root_extrinsic::<polkadot::Call>().ok())
+		})
+		.map(|ext| ext.encode())
+		.collect();
+
+	if extrinsics.contains(&payment.encode()) {
+		Ok(())
+	} else {
+		Err(Error::PaymentNotFound)
+	}
+}
+
+async fn opaque_payment_extrinsic(
+	para: Parachain,
+	payment_info: PaymentInfo,
+) -> Result<polkadot::Call, Error> {
+	if let Ok(cost) = payment_info.cost.parse::<u128>() {
+		let transfer_call = polkadot::Call::Balances(BalancesCall::transfer_keep_alive {
+			dest: payment_info.receiver.into(),
+			value: cost,
+		});
+
+		let remark = format!("{}:{}", para.relay_chain, para.para_id).as_bytes().to_vec();
+		let remark_call = polkadot::Call::System(SystemCall::remark { remark });
+
+		let batch_call = polkadot::Call::Utility(UtilityCall::batch_all {
+			calls: vec![transfer_call, remark_call],
+		});
+
+		Ok(batch_call)
+	} else {
+		log::error!(
+			target: LOG_TARGET,
+			"Failed to parse cost",
+		);
+		Err(Error::PaymentValidationFailed)
+	}
+}
+
+async fn get_last_finalized_block(
+	rpc_client: RpcClient,
+	online_client: OnlineClient<PolkadotConfig>,
+) -> Result<BlockNumber, Error> {
+	let params = rpc_params![];
+	let block_hash: H256 = rpc_client
+		.request("chain_getFinalizedHead", params)
+		.await
+		.map_err(|_| Error::PaymentValidationFailed)?;
+
+	let block = get_block(online_client, block_hash).await?;
+
+	Ok(block.number())
+}
+
+async fn get_block(
+	api: OnlineClient<PolkadotConfig>,
+	block_hash: H256,
+) -> Result<Block<PolkadotConfig, OnlineClient<PolkadotConfig>>, Error> {
+	api.blocks().at(block_hash).await.map_err(|_| Error::PaymentValidationFailed)
+}
+
+async fn get_block_hash(rpc_client: RpcClient, block_number: BlockNumber) -> Result<H256, Error> {
+	let params = rpc_params![Some(block_number)];
+	let block_hash: H256 = rpc_client
+		.request("chain_getBlockHash", params)
+		.await
+		.map_err(|_| Error::PaymentValidationFailed)?;
+
+	Ok(block_hash)
+}

--- a/shared/src/payment.rs
+++ b/shared/src/payment.rs
@@ -47,6 +47,17 @@ pub enum PaymentError {
 	NotFound,
 }
 
+impl From<String> for PaymentError {
+	fn from(v: String) -> Self {
+		match v.as_str() {
+			"ValidationFailed" => Self::ValidationFailed,
+			"Unfinalized" => Self::Unfinalized,
+			"NotFound" => Self::NotFound,
+			_ => panic!("UnknownError"),
+		}
+	}
+}
+
 pub async fn validate_registration_payment(
 	para: Parachain,
 	payment_info: PaymentInfo,


### PR DESCRIPTION
This PR adds a new endpoint for extending a parachain subscription. 

It also moves the payment validation logic into the shared crate, as this functionality is reused when both registering or extending a subscription.