### PR TITLE
Support multiple RPCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /out
+logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +942,52 @@ dependencies = [
  "inout",
  "zeroize",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "common"
@@ -4980,6 +5074,7 @@ dependencies = [
 name = "tracker"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "env_logger",
  "log",
  "shared",
@@ -5146,6 +5241,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/README.md
+++ b/README.md
@@ -53,12 +53,7 @@ A basic example of registering a parachain:
 
 ```
 curl -X POST http://127.0.0.1:8000/register_para -H "Content-Type: application/json" -d '{
-	"para": {
-		"name": "Acala",
-		"rpc_url": "wss://acala-rpc.dwellir.com",
-		"para_id": 2000,
-		"relay_chain": "Polkadot"
-	}
+    "para": ["Polkadot", 2000]                                                 
 }'
 ```
 

--- a/bin/tracker/Cargo.toml
+++ b/bin/tracker/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1", features = ["full"] }
 
 types = { path = "../../types" }
 shared = { path = "../../shared" }
+clap = { version = "4.4.18", features = ["derive"] }

--- a/bin/tracker/src/cli.rs
+++ b/bin/tracker/src/cli.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+
+/// Arguments for the tracker.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+	/// Specifies the index of the RPC to be used.
+	///
+	/// Multiple RPCs may be provided for each parachain on Kusama and Polkadot.
+	/// `rpc_index` selects which RPC from the list will be used.
+	#[arg(short, long)]
+	rpc_index: u8,
+}

--- a/bin/tracker/src/cli.rs
+++ b/bin/tracker/src/cli.rs
@@ -3,11 +3,11 @@ use clap::Parser;
 /// Arguments for the tracker.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-struct Args {
+pub struct Args {
 	/// Specifies the index of the RPC to be used.
 	///
 	/// Multiple RPCs may be provided for each parachain on Kusama and Polkadot.
 	/// `rpc_index` selects which RPC from the list will be used.
 	#[arg(short, long)]
-	rpc_index: u8,
+	pub rpc_index: usize,
 }

--- a/bin/tracker/src/main.rs
+++ b/bin/tracker/src/main.rs
@@ -47,6 +47,8 @@ use shared::{consumption::write_consumption, registry::registered_paras, round_t
 use subxt::{blocks::Block, utils::H256, OnlineClient, PolkadotConfig};
 use types::{Parachain, Timestamp, WeightConsumption};
 
+mod cli;
+
 #[subxt::subxt(runtime_metadata_path = "../../artifacts/metadata.scale")]
 mod polkadot {}
 
@@ -54,9 +56,11 @@ mod polkadot {}
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	env_logger::init();
 
+	let args = cli::Args::parse();
+
 	// Asynchronously subscribes to follow the latest finalized block of each parachain
 	// and continuously fetches the weight consumption.
-	let tasks: Vec<_> = registered_paras()
+	let tasks: Vec<_> = registered_paras(args.rpc_index)
 		.into_iter()
 		.map(|para| tokio::spawn(async move { track_weight_consumption(para).await }))
 		.collect();

--- a/chaindata.json
+++ b/chaindata.json
@@ -44,6 +44,9 @@
     "rpcs": [
       {
         "url": "wss://fullnode.altair.centrifuge.io"
+      },
+      {
+        "url": "wss://altair.api.onfinality.io/public-ws"
       }
     ]
   },
@@ -95,6 +98,9 @@
     "rpcs": [
       {
         "url": "wss://kusama.api.integritee.network"
+      },
+      {
+        "url": "wss://integritee-kusama.api.onfinality.io/public-ws"
       }
     ]
   },
@@ -872,6 +878,9 @@
     "rpcs": [
       {
         "url": "wss://eden-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://nodle-parachain.api.onfinality.io/public-ws"
       }
     ]
   },
@@ -1067,6 +1076,9 @@
     "rpcs": [
       {
         "url": "wss://para.subsocial.network"
+      },
+      {
+        "url": "wss://subsocial-rpc.dwellir.com"
       }
     ]
   },

--- a/chaindata.json
+++ b/chaindata.json
@@ -1,0 +1,1275 @@
+{
+  "data": {
+    "chains": [
+      {
+        "name": "Amplitude",
+        "paraId": 2124,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://amplitude-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc-amplitude.pendulumchain.tech"
+          }
+        ]
+      },
+      {
+        "name": "Encointer",
+        "paraId": 1001,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://sys.ibp.network/encointer-kusama"
+          },
+          {
+            "url": "wss://sys.dotters.network/encointer-kusama"
+          },
+          {
+            "url": "wss://kusama.api.encointer.org"
+          },
+          {
+            "url": "wss://ksm-rpc.stakeworld.io/encointer"
+          }
+        ]
+      },
+      {
+        "name": "Altair",
+        "paraId": 2088,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://fullnode.altair.centrifuge.io"
+          }
+        ]
+      },
+      {
+        "name": "Basilisk",
+        "paraId": 2090,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://basilisk-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.basilisk.cloud"
+          }
+        ]
+      },
+      {
+        "name": "Bit.Country Pioneer",
+        "paraId": 2096,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://pioneer-rpc-3.bit.country/wss"
+          }
+        ]
+      },
+      {
+        "name": "Parallel Heiko",
+        "paraId": 2085,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://heiko-rpc.parallel.fi"
+          }
+        ]
+      },
+      {
+        "name": "Integritee",
+        "paraId": 2015,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama.api.integritee.network"
+          }
+        ]
+      },
+      {
+        "name": "DAO IPCI",
+        "paraId": 2222,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama.rpc.ipci.io"
+          }
+        ]
+      },
+      {
+        "name": "Imbue",
+        "paraId": 2121,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama.imbuenetwork.com"
+          }
+        ]
+      },
+      {
+        "name": "GM",
+        "paraId": 2123,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://ws.gm.bldnodes.org/"
+          }
+        ]
+      },
+      {
+        "name": "Bifrost Kusama",
+        "paraId": 2001,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://bifrost-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://bifrost-rpc.liebi.com/ws"
+          },
+          {
+            "url": "wss://us.bifrost-rpc.liebi.com/ws"
+          }
+        ]
+      },
+      {
+        "name": "Krest",
+        "paraId": 2241,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://wss-krest.peaq.network/"
+          },
+          {
+            "url": "wss://krest.unitedbloc.com/"
+          }
+        ]
+      },
+      {
+        "name": "Kusama Bridge Hub",
+        "paraId": 1002,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama-bridge-hub-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://kusama-bridge-hub-rpc-tn.dwellir.com"
+          },
+          {
+            "url": "wss://sys.ibp.network/bridgehub-kusama"
+          },
+          {
+            "url": "wss://sys.dotters.network/bridgehub-kusama"
+          },
+          {
+            "url": "wss://kusama-bridge-hub-rpc.polkadot.io"
+          },
+          {
+            "url": "wss://ksm-rpc.stakeworld.io/bridgehub"
+          }
+        ]
+      },
+      {
+        "name": "Khala",
+        "paraId": 2004,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://khala-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://khala-api.phala.network/ws"
+          }
+        ]
+      },
+      {
+        "name": "Kusama Asset Hub",
+        "paraId": 1000,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://statemine-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://statemine-rpc-tn.dwellir.com"
+          },
+          {
+            "url": "wss://sys.ibp.network/statemine"
+          },
+          {
+            "url": "wss://sys.dotters.network/statemine"
+          },
+          {
+            "url": "wss://rpc-asset-hub-kusama.luckyfriday.io"
+          },
+          {
+            "url": "wss://kusama-asset-hub-rpc.polkadot.io"
+          },
+          {
+            "url": "wss://statemine.public.curie.radiumblock.co/ws"
+          },
+          {
+            "url": "wss://ksm-rpc.stakeworld.io/assethub"
+          }
+        ]
+      },
+      {
+        "name": "Genshiro",
+        "paraId": 2024,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://node.ksm.genshiro.io"
+          },
+          {
+            "url": "wss://node.genshiro.io"
+          }
+        ]
+      },
+      {
+        "name": "Moonriver",
+        "paraId": 2023,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://moonriver-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://wss.api.moonriver.moonbeam.network"
+          },
+          {
+            "url": "wss://moonriver.unitedbloc.com"
+          }
+        ]
+      },
+      {
+        "name": "Litmus",
+        "paraId": 2106,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc.litmus-parachain.litentry.io"
+          }
+        ]
+      },
+      {
+        "name": "Robonomics",
+        "paraId": 2048,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama.rpc.robonomics.network/"
+          },
+          {
+            "url": "wss://robonomics.0xsamsara.com"
+          }
+        ]
+      },
+      {
+        "name": "Quartz",
+        "paraId": 2095,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://quartz-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://ws-quartz.unique.network"
+          },
+          {
+            "url": "wss://us-ws-quartz.unique.network"
+          },
+          {
+            "url": "wss://asia-ws-quartz.unique.network"
+          },
+          {
+            "url": "wss://eu-ws-quartz.unique.network"
+          }
+        ]
+      },
+      {
+        "name": "Sora",
+        "paraId": 2011,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://ws.parachain-collator-1.c1.sora2.soramitsu.co.jp"
+          }
+        ]
+      },
+      {
+        "name": "Shiden",
+        "paraId": 2007,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://shiden-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.shiden.astar.network"
+          }
+        ]
+      },
+      {
+        "name": "Crust Shadow",
+        "paraId": 2012,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc-shadow.crust.network/"
+          }
+        ]
+      },
+      {
+        "name": "InvArch Tinkernet",
+        "paraId": 2125,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://tinkernet-rpc.dwellir.com"
+          }
+        ]
+      },
+      {
+        "name": "Turing",
+        "paraId": 2114,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://turing-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.turing.oak.tech"
+          }
+        ]
+      },
+      {
+        "name": "Subzero",
+        "paraId": 2236,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc-1.kusama.node.zero.io"
+          }
+        ]
+      },
+      {
+        "name": "Picasso",
+        "paraId": 2087,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://picasso-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.composablenodes.tech"
+          }
+        ]
+      },
+      {
+        "name": "Karura",
+        "paraId": 2000,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://karura-rpc-0.aca-api.network"
+          },
+          {
+            "url": "wss://karura-rpc-1.aca-api.network"
+          },
+          {
+            "url": "wss://karura-rpc-2.aca-api.network/ws"
+          },
+          {
+            "url": "wss://karura-rpc-3.aca-api.network/ws"
+          }
+        ]
+      },
+      {
+        "name": "MangataX",
+        "paraId": 2110,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama-archive.mangata.online"
+          },
+          {
+            "url": "wss://kusama-rpc.mangata.online"
+          }
+        ]
+      },
+      {
+        "name": "Acurast Canary",
+        "paraId": 2239,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://acurast-canarynet-ws.prod.gke.papers.tech"
+          }
+        ]
+      },
+      {
+        "name": "Kabocha",
+        "paraId": 2113,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kabocha.jelliedowl.net"
+          }
+        ]
+      },
+      {
+        "name": "t1rn",
+        "paraId": 3334,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc.t1rn.io"
+          }
+        ]
+      },
+      {
+        "name": "Kintsugi",
+        "paraId": 2092,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kintsugi-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://api-kusama.interlay.io/parachain"
+          }
+        ]
+      },
+      {
+        "name": "Kreivo - By Virto",
+        "paraId": 2281,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kreivo.io/"
+          }
+        ]
+      },
+      {
+        "name": "Kpron",
+        "paraId": 2019,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kusama-kpron-rpc.apron.network/"
+          }
+        ]
+      },
+      {
+        "name": "Sakura",
+        "paraId": 2016,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://api-sakura.clover.finance"
+          }
+        ]
+      },
+      {
+        "name": "Quantum Portal",
+        "paraId": 2274,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://qpn.svcs.ferrumnetwork.io/"
+          }
+        ]
+      },
+      {
+        "name": "Bajun",
+        "paraId": 2119,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc-parachain.bajun.network"
+          },
+          {
+            "url": "wss://bajun.public.curie.radiumblock.co/ws"
+          }
+        ]
+      },
+      {
+        "name": "Calamari",
+        "paraId": 2084,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://calamari.systems"
+          }
+        ]
+      },
+      {
+        "name": "Darwinia Crab",
+        "paraId": 2105,
+        "relay": {
+          "id": "kusama"
+        },
+        "rpcs": [
+          {
+            "url": "wss://darwiniacrab-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://crab-rpc.darwinia.network/"
+          },
+          {
+            "url": "wss://crab-rpc.darwiniacommunitydao.xyz"
+          }
+        ]
+      },
+      {
+        "name": "Ajuna",
+        "paraId": 2051,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc-parachain.ajuna.network"
+          },
+          {
+            "url": "wss://ajuna.public.curie.radiumblock.co/ws"
+          }
+        ]
+      },
+      {
+        "name": "Litentry",
+        "paraId": 2013,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://litentry-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.litentry-parachain.litentry.io"
+          }
+        ]
+      },
+      {
+        "name": "Energy Web X",
+        "paraId": 3345,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://public-rpc.mainnet.energywebx.com"
+          }
+        ]
+      },
+      {
+        "name": "Acala",
+        "paraId": 2000,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://acala-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://acala-rpc-0.aca-api.network"
+          },
+          {
+            "url": "wss://acala-rpc-1.aca-api.network"
+          },
+          {
+            "url": "wss://acala-rpc-3.aca-api.network/ws"
+          }
+        ]
+      },
+      {
+        "name": "Crust",
+        "paraId": 2008,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://crust-parachain.crustapps.net"
+          }
+        ]
+      },
+      {
+        "name": "Clover",
+        "paraId": 2002,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc-para.clover.finance"
+          }
+        ]
+      },
+      {
+        "name": "Darwinia",
+        "paraId": 2046,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://darwinia-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.darwinia.network"
+          },
+          {
+            "url": "wss://darwinia-rpc.darwiniacommunitydao.xyz"
+          }
+        ]
+      },
+      {
+        "name": "Centrifuge",
+        "paraId": 2031,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://centrifuge-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://fullnode.centrifuge.io"
+          },
+          {
+            "url": "wss://rpc-centrifuge.luckyfriday.io"
+          }
+        ]
+      },
+      {
+        "name": "InvArch",
+        "paraId": 3340,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://invarch-rpc.dwellir.com"
+          }
+        ]
+      },
+      {
+        "name": "Composable Finance",
+        "paraId": 2019,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://composable-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.composable.finance"
+          }
+        ]
+      },
+      {
+        "name": "Astar",
+        "paraId": 2006,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://astar-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.astar.network"
+          },
+          {
+            "url": "wss://1rpc.io/astr"
+          },
+          {
+            "url": "wss://astar.public.curie.radiumblock.co/ws"
+          }
+        ]
+      },
+      {
+        "name": "KILT Spiritnet",
+        "paraId": 2086,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kilt-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://spiritnet.kilt.io/"
+          }
+        ]
+      },
+      {
+        "name": "Bifrost Polkadot",
+        "paraId": 2030,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://hk.p.bifrost-rpc.liebi.com/ws"
+          },
+          {
+            "url": "wss://eu.bifrost-polkadot-rpc.liebi.com/ws"
+          }
+        ]
+      },
+      {
+        "name": "HydraDX",
+        "paraId": 2034,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://hydradx-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.hydradx.cloud"
+          }
+        ]
+      },
+      {
+        "name": "Manta",
+        "paraId": 2104,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://ws.manta.systems"
+          }
+        ]
+      },
+      {
+        "name": "Moonbeam",
+        "paraId": 2004,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://moonbeam-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://1rpc.io/glmr"
+          },
+          {
+            "url": "wss://wss.api.moonbeam.network"
+          },
+          {
+            "url": "wss://moonbeam.unitedbloc.com"
+          }
+        ]
+      },
+      {
+        "name": "Nodle",
+        "paraId": 2026,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://eden-rpc.dwellir.com"
+          }
+        ]
+      },
+      {
+        "name": "Moonsama",
+        "paraId": 3334,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc.moonsama.com/ws"
+          }
+        ]
+      },
+      {
+        "name": "OriginTrail",
+        "paraId": 2043,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://origintrail-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://parachain-rpc.origin-trail.network"
+          }
+        ]
+      },
+      {
+        "name": "Phala",
+        "paraId": 2035,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://phala-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://api.phala.network/ws"
+          }
+        ]
+      },
+      {
+        "name": "Polkadex",
+        "paraId": 2040,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://polkadex-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://polkadex-parachain.public.curie.radiumblock.co/ws"
+          }
+        ]
+      },
+      {
+        "name": "Polkadot Bridge Hub",
+        "paraId": 1002,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://polkadot-bridge-hub-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://polkadot-bridge-hub-rpc-tn.dwellir.com"
+          },
+          {
+            "url": "wss://sys.ibp.network/bridgehub-polkadot"
+          },
+          {
+            "url": "wss://sys.dotters.network/bridgehub-polkadot"
+          },
+          {
+            "url": "wss://rpc-bridge-hub-polkadot.luckyfriday.io"
+          },
+          {
+            "url": "wss://polkadot-bridge-hub-rpc.polkadot.io"
+          },
+          {
+            "url": "wss://dot-rpc.stakeworld.io/bridgehub"
+          }
+        ]
+      },
+      {
+        "name": "Parallel",
+        "paraId": 2012,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://parallel-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc.parallel.fi"
+          }
+        ]
+      },
+      {
+        "name": "Collectives",
+        "paraId": 1001,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://polkadot-collectives-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://polkadot-collectives-rpc-tn.dwellir.com"
+          },
+          {
+            "url": "wss://sys.ibp.network/collectives-polkadot"
+          },
+          {
+            "url": "wss://sys.dotters.network/collectives-polkadot"
+          },
+          {
+            "url": "wss://rpc-collectives-polkadot.luckyfriday.io"
+          },
+          {
+            "url": "wss://polkadot-collectives-rpc.polkadot.io"
+          },
+          {
+            "url": "wss://collectives.public.curie.radiumblock.co/ws"
+          },
+          {
+            "url": "wss://dot-rpc.stakeworld.io/collectives"
+          }
+        ]
+      },
+      {
+        "name": "Pendulum",
+        "paraId": 2094,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://pendulum-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://rpc-pendulum.prd.pendulumchain.tech"
+          }
+        ]
+      },
+      {
+        "name": "Polkadot Asset Hub",
+        "paraId": 1000,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://statemint-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://statemint-rpc-tn.dwellir.com"
+          },
+          {
+            "url": "wss://sys.ibp.network/statemint"
+          },
+          {
+            "url": "wss://sys.dotters.network/statemint"
+          },
+          {
+            "url": "wss://rpc-asset-hub-polkadot.luckyfriday.io"
+          },
+          {
+            "url": "wss://polkadot-asset-hub-rpc.polkadot.io"
+          },
+          {
+            "url": "wss://statemint.public.curie.radiumblock.co/ws"
+          },
+          {
+            "url": "wss://dot-rpc.stakeworld.io/assethub"
+          }
+        ]
+      },
+      {
+        "name": "Subsocial",
+        "paraId": 2101,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://para.subsocial.network"
+          }
+        ]
+      },
+      {
+        "name": "Watr",
+        "paraId": 2058,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://watr-rpc.watr-api.network"
+          }
+        ]
+      },
+      {
+        "name": "Zeitgeist",
+        "paraId": 2092,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://zeitgeist-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://main.rpc.zeitgeist.pm/ws"
+          }
+        ]
+      },
+      {
+        "name": "Unique",
+        "paraId": 2037,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://unique-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://ws.unique.network"
+          },
+          {
+            "url": "wss://us-ws.unique.network"
+          },
+          {
+            "url": "wss://asia-ws.unique.network"
+          },
+          {
+            "url": "wss://eu-ws.unique.network"
+          }
+        ]
+      },
+      {
+        "name": "Equilibrium",
+        "paraId": 2011,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://equilibrium-rpc.dwellir.com"
+          }
+        ]
+      },
+      {
+        "name": "Interlay",
+        "paraId": 2032,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://interlay-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://api.interlay.io/parachain"
+          },
+          {
+            "url": "wss://rpc-interlay.luckyfriday.io/"
+          }
+        ]
+      },
+      {
+        "name": "Kapex",
+        "paraId": 2007,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://kapex-rpc.dwellir.com"
+          }
+        ]
+      },
+      {
+        "name": "Frequency",
+        "paraId": 2091,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://frequency-rpc.dwellir.com"
+          },
+          {
+            "url": "wss://0.rpc.frequency.xyz"
+          },
+          {
+            "url": "wss://1.rpc.frequency.xyz"
+          }
+        ]
+      },
+      {
+        "name": "t3rn",
+        "paraId": 3333,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://ws.t3rn.io"
+          }
+        ]
+      },
+      {
+        "name": "Geminis",
+        "paraId": 2038,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc.geminis.network"
+          }
+        ]
+      },
+      {
+        "name": "Oak",
+        "paraId": 2090,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://rpc.oak.tech"
+          }
+        ]
+      },
+      {
+        "name": "SubDAO",
+        "paraId": 2018,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://parachain-rpc.subdao.org"
+          }
+        ]
+      },
+      {
+        "name": "OmniBTC",
+        "paraId": 2053,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://psc-parachain.coming.chat"
+          }
+        ]
+      },
+      {
+        "name": "Bitgreen",
+        "paraId": 2048,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://mainnet.bitgreen.org"
+          }
+        ]
+      },
+      {
+        "name": "Hashed",
+        "paraId": 2093,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://c1.hashed.live"
+          },
+          {
+            "url": "wss://c2.hashed.network"
+          },
+          {
+            "url": "wss://c3.hashed.live"
+          }
+        ]
+      },
+      {
+        "name": "Aventus",
+        "paraId": 2056,
+        "relay": {
+          "id": "polkadot"
+        },
+        "rpcs": [
+          {
+            "url": "wss://public-rpc.mainnet.aventus.io"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/chaindata.json
+++ b/chaindata.json
@@ -1,1275 +1,1271 @@
-{
-  "data": {
-    "chains": [
-      {
-        "name": "Amplitude",
-        "paraId": 2124,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://amplitude-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc-amplitude.pendulumchain.tech"
-          }
-        ]
-      },
-      {
-        "name": "Encointer",
-        "paraId": 1001,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://sys.ibp.network/encointer-kusama"
-          },
-          {
-            "url": "wss://sys.dotters.network/encointer-kusama"
-          },
-          {
-            "url": "wss://kusama.api.encointer.org"
-          },
-          {
-            "url": "wss://ksm-rpc.stakeworld.io/encointer"
-          }
-        ]
-      },
-      {
-        "name": "Altair",
-        "paraId": 2088,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://fullnode.altair.centrifuge.io"
-          }
-        ]
-      },
-      {
-        "name": "Basilisk",
-        "paraId": 2090,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://basilisk-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.basilisk.cloud"
-          }
-        ]
-      },
-      {
-        "name": "Bit.Country Pioneer",
-        "paraId": 2096,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://pioneer-rpc-3.bit.country/wss"
-          }
-        ]
-      },
-      {
-        "name": "Parallel Heiko",
-        "paraId": 2085,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://heiko-rpc.parallel.fi"
-          }
-        ]
-      },
-      {
-        "name": "Integritee",
-        "paraId": 2015,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama.api.integritee.network"
-          }
-        ]
-      },
-      {
-        "name": "DAO IPCI",
-        "paraId": 2222,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama.rpc.ipci.io"
-          }
-        ]
-      },
-      {
-        "name": "Imbue",
-        "paraId": 2121,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama.imbuenetwork.com"
-          }
-        ]
-      },
-      {
-        "name": "GM",
-        "paraId": 2123,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://ws.gm.bldnodes.org/"
-          }
-        ]
-      },
-      {
-        "name": "Bifrost Kusama",
-        "paraId": 2001,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://bifrost-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://bifrost-rpc.liebi.com/ws"
-          },
-          {
-            "url": "wss://us.bifrost-rpc.liebi.com/ws"
-          }
-        ]
-      },
-      {
-        "name": "Krest",
-        "paraId": 2241,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://wss-krest.peaq.network/"
-          },
-          {
-            "url": "wss://krest.unitedbloc.com/"
-          }
-        ]
-      },
-      {
-        "name": "Kusama Bridge Hub",
-        "paraId": 1002,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama-bridge-hub-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://kusama-bridge-hub-rpc-tn.dwellir.com"
-          },
-          {
-            "url": "wss://sys.ibp.network/bridgehub-kusama"
-          },
-          {
-            "url": "wss://sys.dotters.network/bridgehub-kusama"
-          },
-          {
-            "url": "wss://kusama-bridge-hub-rpc.polkadot.io"
-          },
-          {
-            "url": "wss://ksm-rpc.stakeworld.io/bridgehub"
-          }
-        ]
-      },
-      {
-        "name": "Khala",
-        "paraId": 2004,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://khala-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://khala-api.phala.network/ws"
-          }
-        ]
-      },
-      {
-        "name": "Kusama Asset Hub",
-        "paraId": 1000,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://statemine-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://statemine-rpc-tn.dwellir.com"
-          },
-          {
-            "url": "wss://sys.ibp.network/statemine"
-          },
-          {
-            "url": "wss://sys.dotters.network/statemine"
-          },
-          {
-            "url": "wss://rpc-asset-hub-kusama.luckyfriday.io"
-          },
-          {
-            "url": "wss://kusama-asset-hub-rpc.polkadot.io"
-          },
-          {
-            "url": "wss://statemine.public.curie.radiumblock.co/ws"
-          },
-          {
-            "url": "wss://ksm-rpc.stakeworld.io/assethub"
-          }
-        ]
-      },
-      {
-        "name": "Genshiro",
-        "paraId": 2024,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://node.ksm.genshiro.io"
-          },
-          {
-            "url": "wss://node.genshiro.io"
-          }
-        ]
-      },
-      {
-        "name": "Moonriver",
-        "paraId": 2023,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://moonriver-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://wss.api.moonriver.moonbeam.network"
-          },
-          {
-            "url": "wss://moonriver.unitedbloc.com"
-          }
-        ]
-      },
-      {
-        "name": "Litmus",
-        "paraId": 2106,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc.litmus-parachain.litentry.io"
-          }
-        ]
-      },
-      {
-        "name": "Robonomics",
-        "paraId": 2048,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama.rpc.robonomics.network/"
-          },
-          {
-            "url": "wss://robonomics.0xsamsara.com"
-          }
-        ]
-      },
-      {
-        "name": "Quartz",
-        "paraId": 2095,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://quartz-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://ws-quartz.unique.network"
-          },
-          {
-            "url": "wss://us-ws-quartz.unique.network"
-          },
-          {
-            "url": "wss://asia-ws-quartz.unique.network"
-          },
-          {
-            "url": "wss://eu-ws-quartz.unique.network"
-          }
-        ]
-      },
-      {
-        "name": "Sora",
-        "paraId": 2011,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://ws.parachain-collator-1.c1.sora2.soramitsu.co.jp"
-          }
-        ]
-      },
-      {
-        "name": "Shiden",
-        "paraId": 2007,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://shiden-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.shiden.astar.network"
-          }
-        ]
-      },
-      {
-        "name": "Crust Shadow",
-        "paraId": 2012,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc-shadow.crust.network/"
-          }
-        ]
-      },
-      {
-        "name": "InvArch Tinkernet",
-        "paraId": 2125,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://tinkernet-rpc.dwellir.com"
-          }
-        ]
-      },
-      {
-        "name": "Turing",
-        "paraId": 2114,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://turing-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.turing.oak.tech"
-          }
-        ]
-      },
-      {
-        "name": "Subzero",
-        "paraId": 2236,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc-1.kusama.node.zero.io"
-          }
-        ]
-      },
-      {
-        "name": "Picasso",
-        "paraId": 2087,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://picasso-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.composablenodes.tech"
-          }
-        ]
-      },
-      {
-        "name": "Karura",
-        "paraId": 2000,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://karura-rpc-0.aca-api.network"
-          },
-          {
-            "url": "wss://karura-rpc-1.aca-api.network"
-          },
-          {
-            "url": "wss://karura-rpc-2.aca-api.network/ws"
-          },
-          {
-            "url": "wss://karura-rpc-3.aca-api.network/ws"
-          }
-        ]
-      },
-      {
-        "name": "MangataX",
-        "paraId": 2110,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama-archive.mangata.online"
-          },
-          {
-            "url": "wss://kusama-rpc.mangata.online"
-          }
-        ]
-      },
-      {
-        "name": "Acurast Canary",
-        "paraId": 2239,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://acurast-canarynet-ws.prod.gke.papers.tech"
-          }
-        ]
-      },
-      {
-        "name": "Kabocha",
-        "paraId": 2113,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kabocha.jelliedowl.net"
-          }
-        ]
-      },
-      {
-        "name": "t1rn",
-        "paraId": 3334,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc.t1rn.io"
-          }
-        ]
-      },
-      {
-        "name": "Kintsugi",
-        "paraId": 2092,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kintsugi-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://api-kusama.interlay.io/parachain"
-          }
-        ]
-      },
-      {
-        "name": "Kreivo - By Virto",
-        "paraId": 2281,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kreivo.io/"
-          }
-        ]
-      },
-      {
-        "name": "Kpron",
-        "paraId": 2019,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kusama-kpron-rpc.apron.network/"
-          }
-        ]
-      },
-      {
-        "name": "Sakura",
-        "paraId": 2016,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://api-sakura.clover.finance"
-          }
-        ]
-      },
-      {
-        "name": "Quantum Portal",
-        "paraId": 2274,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://qpn.svcs.ferrumnetwork.io/"
-          }
-        ]
-      },
-      {
-        "name": "Bajun",
-        "paraId": 2119,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc-parachain.bajun.network"
-          },
-          {
-            "url": "wss://bajun.public.curie.radiumblock.co/ws"
-          }
-        ]
-      },
-      {
-        "name": "Calamari",
-        "paraId": 2084,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://calamari.systems"
-          }
-        ]
-      },
-      {
-        "name": "Darwinia Crab",
-        "paraId": 2105,
-        "relay": {
-          "id": "kusama"
-        },
-        "rpcs": [
-          {
-            "url": "wss://darwiniacrab-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://crab-rpc.darwinia.network/"
-          },
-          {
-            "url": "wss://crab-rpc.darwiniacommunitydao.xyz"
-          }
-        ]
-      },
-      {
-        "name": "Ajuna",
-        "paraId": 2051,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc-parachain.ajuna.network"
-          },
-          {
-            "url": "wss://ajuna.public.curie.radiumblock.co/ws"
-          }
-        ]
-      },
-      {
-        "name": "Litentry",
-        "paraId": 2013,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://litentry-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.litentry-parachain.litentry.io"
-          }
-        ]
-      },
-      {
-        "name": "Energy Web X",
-        "paraId": 3345,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://public-rpc.mainnet.energywebx.com"
-          }
-        ]
-      },
-      {
-        "name": "Acala",
-        "paraId": 2000,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://acala-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://acala-rpc-0.aca-api.network"
-          },
-          {
-            "url": "wss://acala-rpc-1.aca-api.network"
-          },
-          {
-            "url": "wss://acala-rpc-3.aca-api.network/ws"
-          }
-        ]
-      },
-      {
-        "name": "Crust",
-        "paraId": 2008,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://crust-parachain.crustapps.net"
-          }
-        ]
-      },
-      {
-        "name": "Clover",
-        "paraId": 2002,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc-para.clover.finance"
-          }
-        ]
-      },
-      {
-        "name": "Darwinia",
-        "paraId": 2046,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://darwinia-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.darwinia.network"
-          },
-          {
-            "url": "wss://darwinia-rpc.darwiniacommunitydao.xyz"
-          }
-        ]
-      },
-      {
-        "name": "Centrifuge",
-        "paraId": 2031,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://centrifuge-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://fullnode.centrifuge.io"
-          },
-          {
-            "url": "wss://rpc-centrifuge.luckyfriday.io"
-          }
-        ]
-      },
-      {
-        "name": "InvArch",
-        "paraId": 3340,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://invarch-rpc.dwellir.com"
-          }
-        ]
-      },
-      {
-        "name": "Composable Finance",
-        "paraId": 2019,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://composable-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.composable.finance"
-          }
-        ]
-      },
-      {
-        "name": "Astar",
-        "paraId": 2006,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://astar-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.astar.network"
-          },
-          {
-            "url": "wss://1rpc.io/astr"
-          },
-          {
-            "url": "wss://astar.public.curie.radiumblock.co/ws"
-          }
-        ]
-      },
-      {
-        "name": "KILT Spiritnet",
-        "paraId": 2086,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kilt-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://spiritnet.kilt.io/"
-          }
-        ]
-      },
-      {
-        "name": "Bifrost Polkadot",
-        "paraId": 2030,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://hk.p.bifrost-rpc.liebi.com/ws"
-          },
-          {
-            "url": "wss://eu.bifrost-polkadot-rpc.liebi.com/ws"
-          }
-        ]
-      },
-      {
-        "name": "HydraDX",
-        "paraId": 2034,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://hydradx-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.hydradx.cloud"
-          }
-        ]
-      },
-      {
-        "name": "Manta",
-        "paraId": 2104,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://ws.manta.systems"
-          }
-        ]
-      },
-      {
-        "name": "Moonbeam",
-        "paraId": 2004,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://moonbeam-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://1rpc.io/glmr"
-          },
-          {
-            "url": "wss://wss.api.moonbeam.network"
-          },
-          {
-            "url": "wss://moonbeam.unitedbloc.com"
-          }
-        ]
-      },
-      {
-        "name": "Nodle",
-        "paraId": 2026,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://eden-rpc.dwellir.com"
-          }
-        ]
-      },
-      {
-        "name": "Moonsama",
-        "paraId": 3334,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc.moonsama.com/ws"
-          }
-        ]
-      },
-      {
-        "name": "OriginTrail",
-        "paraId": 2043,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://origintrail-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://parachain-rpc.origin-trail.network"
-          }
-        ]
-      },
-      {
-        "name": "Phala",
-        "paraId": 2035,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://phala-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://api.phala.network/ws"
-          }
-        ]
-      },
-      {
-        "name": "Polkadex",
-        "paraId": 2040,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://polkadex-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://polkadex-parachain.public.curie.radiumblock.co/ws"
-          }
-        ]
-      },
-      {
-        "name": "Polkadot Bridge Hub",
-        "paraId": 1002,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://polkadot-bridge-hub-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://polkadot-bridge-hub-rpc-tn.dwellir.com"
-          },
-          {
-            "url": "wss://sys.ibp.network/bridgehub-polkadot"
-          },
-          {
-            "url": "wss://sys.dotters.network/bridgehub-polkadot"
-          },
-          {
-            "url": "wss://rpc-bridge-hub-polkadot.luckyfriday.io"
-          },
-          {
-            "url": "wss://polkadot-bridge-hub-rpc.polkadot.io"
-          },
-          {
-            "url": "wss://dot-rpc.stakeworld.io/bridgehub"
-          }
-        ]
-      },
-      {
-        "name": "Parallel",
-        "paraId": 2012,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://parallel-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc.parallel.fi"
-          }
-        ]
-      },
-      {
-        "name": "Collectives",
-        "paraId": 1001,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://polkadot-collectives-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://polkadot-collectives-rpc-tn.dwellir.com"
-          },
-          {
-            "url": "wss://sys.ibp.network/collectives-polkadot"
-          },
-          {
-            "url": "wss://sys.dotters.network/collectives-polkadot"
-          },
-          {
-            "url": "wss://rpc-collectives-polkadot.luckyfriday.io"
-          },
-          {
-            "url": "wss://polkadot-collectives-rpc.polkadot.io"
-          },
-          {
-            "url": "wss://collectives.public.curie.radiumblock.co/ws"
-          },
-          {
-            "url": "wss://dot-rpc.stakeworld.io/collectives"
-          }
-        ]
-      },
-      {
-        "name": "Pendulum",
-        "paraId": 2094,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://pendulum-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://rpc-pendulum.prd.pendulumchain.tech"
-          }
-        ]
-      },
-      {
-        "name": "Polkadot Asset Hub",
-        "paraId": 1000,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://statemint-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://statemint-rpc-tn.dwellir.com"
-          },
-          {
-            "url": "wss://sys.ibp.network/statemint"
-          },
-          {
-            "url": "wss://sys.dotters.network/statemint"
-          },
-          {
-            "url": "wss://rpc-asset-hub-polkadot.luckyfriday.io"
-          },
-          {
-            "url": "wss://polkadot-asset-hub-rpc.polkadot.io"
-          },
-          {
-            "url": "wss://statemint.public.curie.radiumblock.co/ws"
-          },
-          {
-            "url": "wss://dot-rpc.stakeworld.io/assethub"
-          }
-        ]
-      },
-      {
-        "name": "Subsocial",
-        "paraId": 2101,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://para.subsocial.network"
-          }
-        ]
-      },
-      {
-        "name": "Watr",
-        "paraId": 2058,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://watr-rpc.watr-api.network"
-          }
-        ]
-      },
-      {
-        "name": "Zeitgeist",
-        "paraId": 2092,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://zeitgeist-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://main.rpc.zeitgeist.pm/ws"
-          }
-        ]
-      },
-      {
-        "name": "Unique",
-        "paraId": 2037,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://unique-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://ws.unique.network"
-          },
-          {
-            "url": "wss://us-ws.unique.network"
-          },
-          {
-            "url": "wss://asia-ws.unique.network"
-          },
-          {
-            "url": "wss://eu-ws.unique.network"
-          }
-        ]
-      },
-      {
-        "name": "Equilibrium",
-        "paraId": 2011,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://equilibrium-rpc.dwellir.com"
-          }
-        ]
-      },
-      {
-        "name": "Interlay",
-        "paraId": 2032,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://interlay-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://api.interlay.io/parachain"
-          },
-          {
-            "url": "wss://rpc-interlay.luckyfriday.io/"
-          }
-        ]
-      },
-      {
-        "name": "Kapex",
-        "paraId": 2007,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://kapex-rpc.dwellir.com"
-          }
-        ]
-      },
-      {
-        "name": "Frequency",
-        "paraId": 2091,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://frequency-rpc.dwellir.com"
-          },
-          {
-            "url": "wss://0.rpc.frequency.xyz"
-          },
-          {
-            "url": "wss://1.rpc.frequency.xyz"
-          }
-        ]
-      },
-      {
-        "name": "t3rn",
-        "paraId": 3333,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://ws.t3rn.io"
-          }
-        ]
-      },
-      {
-        "name": "Geminis",
-        "paraId": 2038,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc.geminis.network"
-          }
-        ]
-      },
-      {
-        "name": "Oak",
-        "paraId": 2090,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://rpc.oak.tech"
-          }
-        ]
-      },
-      {
-        "name": "SubDAO",
-        "paraId": 2018,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://parachain-rpc.subdao.org"
-          }
-        ]
-      },
-      {
-        "name": "OmniBTC",
-        "paraId": 2053,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://psc-parachain.coming.chat"
-          }
-        ]
-      },
-      {
-        "name": "Bitgreen",
-        "paraId": 2048,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://mainnet.bitgreen.org"
-          }
-        ]
-      },
-      {
-        "name": "Hashed",
-        "paraId": 2093,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://c1.hashed.live"
-          },
-          {
-            "url": "wss://c2.hashed.network"
-          },
-          {
-            "url": "wss://c3.hashed.live"
-          }
-        ]
-      },
-      {
-        "name": "Aventus",
-        "paraId": 2056,
-        "relay": {
-          "id": "polkadot"
-        },
-        "rpcs": [
-          {
-            "url": "wss://public-rpc.mainnet.aventus.io"
-          }
-        ]
+[
+  {
+    "name": "Amplitude",
+    "para_id": 2124,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://amplitude-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc-amplitude.pendulumchain.tech"
+      }
+    ]
+  },
+  {
+    "name": "Encointer",
+    "para_id": 1001,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://sys.ibp.network/encointer-kusama"
+      },
+      {
+        "url": "wss://sys.dotters.network/encointer-kusama"
+      },
+      {
+        "url": "wss://kusama.api.encointer.org"
+      },
+      {
+        "url": "wss://ksm-rpc.stakeworld.io/encointer"
+      }
+    ]
+  },
+  {
+    "name": "Altair",
+    "para_id": 2088,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://fullnode.altair.centrifuge.io"
+      }
+    ]
+  },
+  {
+    "name": "Basilisk",
+    "para_id": 2090,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://basilisk-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.basilisk.cloud"
+      }
+    ]
+  },
+  {
+    "name": "Bit.Country Pioneer",
+    "para_id": 2096,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://pioneer-rpc-3.bit.country/wss"
+      }
+    ]
+  },
+  {
+    "name": "Parallel Heiko",
+    "para_id": 2085,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://heiko-rpc.parallel.fi"
+      }
+    ]
+  },
+  {
+    "name": "Integritee",
+    "para_id": 2015,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama.api.integritee.network"
+      }
+    ]
+  },
+  {
+    "name": "DAO IPCI",
+    "para_id": 2222,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama.rpc.ipci.io"
+      }
+    ]
+  },
+  {
+    "name": "Imbue",
+    "para_id": 2121,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama.imbuenetwork.com"
+      }
+    ]
+  },
+  {
+    "name": "GM",
+    "para_id": 2123,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://ws.gm.bldnodes.org/"
+      }
+    ]
+  },
+  {
+    "name": "Bifrost Kusama",
+    "para_id": 2001,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://bifrost-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://bifrost-rpc.liebi.com/ws"
+      },
+      {
+        "url": "wss://us.bifrost-rpc.liebi.com/ws"
+      }
+    ]
+  },
+  {
+    "name": "Krest",
+    "para_id": 2241,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://wss-krest.peaq.network/"
+      },
+      {
+        "url": "wss://krest.unitedbloc.com/"
+      }
+    ]
+  },
+  {
+    "name": "Kusama Bridge Hub",
+    "para_id": 1002,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama-bridge-hub-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://kusama-bridge-hub-rpc-tn.dwellir.com"
+      },
+      {
+        "url": "wss://sys.ibp.network/bridgehub-kusama"
+      },
+      {
+        "url": "wss://sys.dotters.network/bridgehub-kusama"
+      },
+      {
+        "url": "wss://kusama-bridge-hub-rpc.polkadot.io"
+      },
+      {
+        "url": "wss://ksm-rpc.stakeworld.io/bridgehub"
+      }
+    ]
+  },
+  {
+    "name": "Khala",
+    "para_id": 2004,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://khala-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://khala-api.phala.network/ws"
+      }
+    ]
+  },
+  {
+    "name": "Kusama Asset Hub",
+    "para_id": 1000,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://statemine-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://statemine-rpc-tn.dwellir.com"
+      },
+      {
+        "url": "wss://sys.ibp.network/statemine"
+      },
+      {
+        "url": "wss://sys.dotters.network/statemine"
+      },
+      {
+        "url": "wss://rpc-asset-hub-kusama.luckyfriday.io"
+      },
+      {
+        "url": "wss://kusama-asset-hub-rpc.polkadot.io"
+      },
+      {
+        "url": "wss://statemine.public.curie.radiumblock.co/ws"
+      },
+      {
+        "url": "wss://ksm-rpc.stakeworld.io/assethub"
+      }
+    ]
+  },
+  {
+    "name": "Genshiro",
+    "para_id": 2024,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://node.ksm.genshiro.io"
+      },
+      {
+        "url": "wss://node.genshiro.io"
+      }
+    ]
+  },
+  {
+    "name": "Moonriver",
+    "para_id": 2023,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://moonriver-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://wss.api.moonriver.moonbeam.network"
+      },
+      {
+        "url": "wss://moonriver.unitedbloc.com"
+      }
+    ]
+  },
+  {
+    "name": "Litmus",
+    "para_id": 2106,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc.litmus-parachain.litentry.io"
+      }
+    ]
+  },
+  {
+    "name": "Robonomics",
+    "para_id": 2048,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama.rpc.robonomics.network/"
+      },
+      {
+        "url": "wss://robonomics.0xsamsara.com"
+      }
+    ]
+  },
+  {
+    "name": "Quartz",
+    "para_id": 2095,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://quartz-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://ws-quartz.unique.network"
+      },
+      {
+        "url": "wss://us-ws-quartz.unique.network"
+      },
+      {
+        "url": "wss://asia-ws-quartz.unique.network"
+      },
+      {
+        "url": "wss://eu-ws-quartz.unique.network"
+      }
+    ]
+  },
+  {
+    "name": "Sora",
+    "para_id": 2011,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://ws.parachain-collator-1.c1.sora2.soramitsu.co.jp"
+      }
+    ]
+  },
+  {
+    "name": "Shiden",
+    "para_id": 2007,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://shiden-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.shiden.astar.network"
+      }
+    ]
+  },
+  {
+    "name": "Crust Shadow",
+    "para_id": 2012,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc-shadow.crust.network/"
+      }
+    ]
+  },
+  {
+    "name": "InvArch Tinkernet",
+    "para_id": 2125,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://tinkernet-rpc.dwellir.com"
+      }
+    ]
+  },
+  {
+    "name": "Turing",
+    "para_id": 2114,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://turing-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.turing.oak.tech"
+      }
+    ]
+  },
+  {
+    "name": "Subzero",
+    "para_id": 2236,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc-1.kusama.node.zero.io"
+      }
+    ]
+  },
+  {
+    "name": "Picasso",
+    "para_id": 2087,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://picasso-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.composablenodes.tech"
+      }
+    ]
+  },
+  {
+    "name": "Karura",
+    "para_id": 2000,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://karura-rpc-0.aca-api.network"
+      },
+      {
+        "url": "wss://karura-rpc-1.aca-api.network"
+      },
+      {
+        "url": "wss://karura-rpc-2.aca-api.network/ws"
+      },
+      {
+        "url": "wss://karura-rpc-3.aca-api.network/ws"
+      }
+    ]
+  },
+  {
+    "name": "MangataX",
+    "para_id": 2110,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama-archive.mangata.online"
+      },
+      {
+        "url": "wss://kusama-rpc.mangata.online"
+      }
+    ]
+  },
+  {
+    "name": "Acurast Canary",
+    "para_id": 2239,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://acurast-canarynet-ws.prod.gke.papers.tech"
+      }
+    ]
+  },
+  {
+    "name": "Kabocha",
+    "para_id": 2113,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kabocha.jelliedowl.net"
+      }
+    ]
+  },
+  {
+    "name": "t1rn",
+    "para_id": 3334,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc.t1rn.io"
+      }
+    ]
+  },
+  {
+    "name": "Kintsugi",
+    "para_id": 2092,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kintsugi-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://api-kusama.interlay.io/parachain"
+      }
+    ]
+  },
+  {
+    "name": "Kreivo - By Virto",
+    "para_id": 2281,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kreivo.io/"
+      }
+    ]
+  },
+  {
+    "name": "Kpron",
+    "para_id": 2019,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kusama-kpron-rpc.apron.network/"
+      }
+    ]
+  },
+  {
+    "name": "Sakura",
+    "para_id": 2016,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://api-sakura.clover.finance"
+      }
+    ]
+  },
+  {
+    "name": "Quantum Portal",
+    "para_id": 2274,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://qpn.svcs.ferrumnetwork.io/"
+      }
+    ]
+  },
+  {
+    "name": "Bajun",
+    "para_id": 2119,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc-parachain.bajun.network"
+      },
+      {
+        "url": "wss://bajun.public.curie.radiumblock.co/ws"
+      }
+    ]
+  },
+  {
+    "name": "Calamari",
+    "para_id": 2084,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://calamari.systems"
+      }
+    ]
+  },
+  {
+    "name": "Darwinia Crab",
+    "para_id": 2105,
+    "relay": {
+      "id": "kusama"
+    },
+    "rpcs": [
+      {
+        "url": "wss://darwiniacrab-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://crab-rpc.darwinia.network/"
+      },
+      {
+        "url": "wss://crab-rpc.darwiniacommunitydao.xyz"
+      }
+    ]
+  },
+  {
+    "name": "Ajuna",
+    "para_id": 2051,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc-parachain.ajuna.network"
+      },
+      {
+        "url": "wss://ajuna.public.curie.radiumblock.co/ws"
+      }
+    ]
+  },
+  {
+    "name": "Litentry",
+    "para_id": 2013,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://litentry-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.litentry-parachain.litentry.io"
+      }
+    ]
+  },
+  {
+    "name": "Energy Web X",
+    "para_id": 3345,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://public-rpc.mainnet.energywebx.com"
+      }
+    ]
+  },
+  {
+    "name": "Acala",
+    "para_id": 2000,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://acala-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://acala-rpc-0.aca-api.network"
+      },
+      {
+        "url": "wss://acala-rpc-1.aca-api.network"
+      },
+      {
+        "url": "wss://acala-rpc-3.aca-api.network/ws"
+      }
+    ]
+  },
+  {
+    "name": "Crust",
+    "para_id": 2008,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://crust-parachain.crustapps.net"
+      }
+    ]
+  },
+  {
+    "name": "Clover",
+    "para_id": 2002,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc-para.clover.finance"
+      }
+    ]
+  },
+  {
+    "name": "Darwinia",
+    "para_id": 2046,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://darwinia-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.darwinia.network"
+      },
+      {
+        "url": "wss://darwinia-rpc.darwiniacommunitydao.xyz"
+      }
+    ]
+  },
+  {
+    "name": "Centrifuge",
+    "para_id": 2031,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://centrifuge-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://fullnode.centrifuge.io"
+      },
+      {
+        "url": "wss://rpc-centrifuge.luckyfriday.io"
+      }
+    ]
+  },
+  {
+    "name": "InvArch",
+    "para_id": 3340,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://invarch-rpc.dwellir.com"
+      }
+    ]
+  },
+  {
+    "name": "Composable Finance",
+    "para_id": 2019,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://composable-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.composable.finance"
+      }
+    ]
+  },
+  {
+    "name": "Astar",
+    "para_id": 2006,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://astar-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.astar.network"
+      },
+      {
+        "url": "wss://1rpc.io/astr"
+      },
+      {
+        "url": "wss://astar.public.curie.radiumblock.co/ws"
+      }
+    ]
+  },
+  {
+    "name": "KILT Spiritnet",
+    "para_id": 2086,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kilt-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://spiritnet.kilt.io/"
+      }
+    ]
+  },
+  {
+    "name": "Bifrost Polkadot",
+    "para_id": 2030,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://hk.p.bifrost-rpc.liebi.com/ws"
+      },
+      {
+        "url": "wss://eu.bifrost-polkadot-rpc.liebi.com/ws"
+      }
+    ]
+  },
+  {
+    "name": "HydraDX",
+    "para_id": 2034,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://hydradx-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.hydradx.cloud"
+      }
+    ]
+  },
+  {
+    "name": "Manta",
+    "para_id": 2104,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://ws.manta.systems"
+      }
+    ]
+  },
+  {
+    "name": "Moonbeam",
+    "para_id": 2004,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://moonbeam-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://1rpc.io/glmr"
+      },
+      {
+        "url": "wss://wss.api.moonbeam.network"
+      },
+      {
+        "url": "wss://moonbeam.unitedbloc.com"
+      }
+    ]
+  },
+  {
+    "name": "Nodle",
+    "para_id": 2026,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://eden-rpc.dwellir.com"
+      }
+    ]
+  },
+  {
+    "name": "Moonsama",
+    "para_id": 3334,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc.moonsama.com/ws"
+      }
+    ]
+  },
+  {
+    "name": "OriginTrail",
+    "para_id": 2043,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://origintrail-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://parachain-rpc.origin-trail.network"
+      }
+    ]
+  },
+  {
+    "name": "Phala",
+    "para_id": 2035,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://phala-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://api.phala.network/ws"
+      }
+    ]
+  },
+  {
+    "name": "Polkadex",
+    "para_id": 2040,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://polkadex-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://polkadex-parachain.public.curie.radiumblock.co/ws"
+      }
+    ]
+  },
+  {
+    "name": "Polkadot Bridge Hub",
+    "para_id": 1002,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://polkadot-bridge-hub-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://polkadot-bridge-hub-rpc-tn.dwellir.com"
+      },
+      {
+        "url": "wss://sys.ibp.network/bridgehub-polkadot"
+      },
+      {
+        "url": "wss://sys.dotters.network/bridgehub-polkadot"
+      },
+      {
+        "url": "wss://rpc-bridge-hub-polkadot.luckyfriday.io"
+      },
+      {
+        "url": "wss://polkadot-bridge-hub-rpc.polkadot.io"
+      },
+      {
+        "url": "wss://dot-rpc.stakeworld.io/bridgehub"
+      }
+    ]
+  },
+  {
+    "name": "Parallel",
+    "para_id": 2012,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://parallel-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc.parallel.fi"
+      }
+    ]
+  },
+  {
+    "name": "Collectives",
+    "para_id": 1001,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://polkadot-collectives-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://polkadot-collectives-rpc-tn.dwellir.com"
+      },
+      {
+        "url": "wss://sys.ibp.network/collectives-polkadot"
+      },
+      {
+        "url": "wss://sys.dotters.network/collectives-polkadot"
+      },
+      {
+        "url": "wss://rpc-collectives-polkadot.luckyfriday.io"
+      },
+      {
+        "url": "wss://polkadot-collectives-rpc.polkadot.io"
+      },
+      {
+        "url": "wss://collectives.public.curie.radiumblock.co/ws"
+      },
+      {
+        "url": "wss://dot-rpc.stakeworld.io/collectives"
+      }
+    ]
+  },
+  {
+    "name": "Pendulum",
+    "para_id": 2094,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://pendulum-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://rpc-pendulum.prd.pendulumchain.tech"
+      }
+    ]
+  },
+  {
+    "name": "Polkadot Asset Hub",
+    "para_id": 1000,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://statemint-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://statemint-rpc-tn.dwellir.com"
+      },
+      {
+        "url": "wss://sys.ibp.network/statemint"
+      },
+      {
+        "url": "wss://sys.dotters.network/statemint"
+      },
+      {
+        "url": "wss://rpc-asset-hub-polkadot.luckyfriday.io"
+      },
+      {
+        "url": "wss://polkadot-asset-hub-rpc.polkadot.io"
+      },
+      {
+        "url": "wss://statemint.public.curie.radiumblock.co/ws"
+      },
+      {
+        "url": "wss://dot-rpc.stakeworld.io/assethub"
+      }
+    ]
+  },
+  {
+    "name": "Subsocial",
+    "para_id": 2101,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://para.subsocial.network"
+      }
+    ]
+  },
+  {
+    "name": "Watr",
+    "para_id": 2058,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://watr-rpc.watr-api.network"
+      }
+    ]
+  },
+  {
+    "name": "Zeitgeist",
+    "para_id": 2092,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://zeitgeist-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://main.rpc.zeitgeist.pm/ws"
+      }
+    ]
+  },
+  {
+    "name": "Unique",
+    "para_id": 2037,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://unique-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://ws.unique.network"
+      },
+      {
+        "url": "wss://us-ws.unique.network"
+      },
+      {
+        "url": "wss://asia-ws.unique.network"
+      },
+      {
+        "url": "wss://eu-ws.unique.network"
+      }
+    ]
+  },
+  {
+    "name": "Equilibrium",
+    "para_id": 2011,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://equilibrium-rpc.dwellir.com"
+      }
+    ]
+  },
+  {
+    "name": "Interlay",
+    "para_id": 2032,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://interlay-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://api.interlay.io/parachain"
+      },
+      {
+        "url": "wss://rpc-interlay.luckyfriday.io/"
+      }
+    ]
+  },
+  {
+    "name": "Kapex",
+    "para_id": 2007,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://kapex-rpc.dwellir.com"
+      }
+    ]
+  },
+  {
+    "name": "Frequency",
+    "para_id": 2091,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://frequency-rpc.dwellir.com"
+      },
+      {
+        "url": "wss://0.rpc.frequency.xyz"
+      },
+      {
+        "url": "wss://1.rpc.frequency.xyz"
+      }
+    ]
+  },
+  {
+    "name": "t3rn",
+    "para_id": 3333,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://ws.t3rn.io"
+      }
+    ]
+  },
+  {
+    "name": "Geminis",
+    "para_id": 2038,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc.geminis.network"
+      }
+    ]
+  },
+  {
+    "name": "Oak",
+    "para_id": 2090,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://rpc.oak.tech"
+      }
+    ]
+  },
+  {
+    "name": "SubDAO",
+    "para_id": 2018,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://parachain-rpc.subdao.org"
+      }
+    ]
+  },
+  {
+    "name": "OmniBTC",
+    "para_id": 2053,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://psc-parachain.coming.chat"
+      }
+    ]
+  },
+  {
+    "name": "Bitgreen",
+    "para_id": 2048,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://mainnet.bitgreen.org"
+      }
+    ]
+  },
+  {
+    "name": "Hashed",
+    "para_id": 2093,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://c1.hashed.live"
+      },
+      {
+        "url": "wss://c2.hashed.network"
+      },
+      {
+        "url": "wss://c3.hashed.live"
+      }
+    ]
+  },
+  {
+    "name": "Aventus",
+    "para_id": 2056,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://public-rpc.mainnet.aventus.io"
       }
     ]
   }
-}
+]

--- a/chaindata.json
+++ b/chaindata.json
@@ -600,6 +600,21 @@
     ]
   },
   {
+    "name": "Polkadot",
+    "para_id": 0,
+    "relay": {
+      "id": "polkadot"
+    },
+    "rpcs": [
+      {
+        "url": "wss://polkadot.api.onfinality.io/public-ws"
+      },
+      {
+        "url": "wss://rpc-polkadot.luckyfriday.io"
+      }
+    ]
+  },
+  {
     "name": "Ajuna",
     "para_id": 2051,
     "relay": {

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-output_directory = "out"
+output_directory = "out/out"
 registry = "registry.json"
 chaindata = "chaindata.json"
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 output_directory = "out/"
 registry = "registry.json"
+chaindata = "chaindata.json"
 
 #[payment_info]
 #rpc_url = "wss://rococo-rpc.polkadot.io"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-output_directory = "out/"
+output_directory = "out"
 registry = "registry.json"
 chaindata = "chaindata.json"
 

--- a/registry.json
+++ b/registry.json
@@ -1,9 +1,14 @@
 [
   {
     "name": "Acala",
-    "rpc_url": "wss://acala-rpc.dwellir.com",
+    "rpcs": [
+      "wss://acala-rpc.dwellir.com",
+      "wss://acala-rpc-0.aca-api.network",
+      "wss://acala-rpc-1.aca-api.network",
+      "wss://acala-rpc-3.aca-api.network/ws"
+    ],
     "para_id": 2000,
     "relay_chain": "Polkadot",
-    "last_payment_timestamp": 0
+    "last_payment_timestamp": 1706728108
   }
 ]

--- a/registry.json
+++ b/registry.json
@@ -3,6 +3,7 @@
     "name": "Acala",
     "rpc_url": "wss://acala-rpc.dwellir.com",
     "para_id": 2000,
-    "relay_chain": "Polkadot"
+    "relay_chain": "Polkadot",
+    "last_payment_timestamp": 0
   }
 ]

--- a/routes/config.toml
+++ b/routes/config.toml
@@ -1,5 +1,6 @@
 output_directory = "mock-out/"
 registry = "mock-parachains.json"
+chaindata = "../chaindata.json"
 free_mode = true
 
 [payment_info]

--- a/routes/config.toml
+++ b/routes/config.toml
@@ -1,4 +1,4 @@
-output_directory = "mock-out/"
+output_directory = "mock-out"
 registry = "mock-parachains.json"
 chaindata = "../chaindata.json"
 free_mode = true

--- a/routes/src/consumption.rs
+++ b/routes/src/consumption.rs
@@ -35,7 +35,8 @@ pub fn consumption(
 	let (page, page_size) = (page.unwrap_or_default(), page_size.unwrap_or(u32::MAX));
 	let (start, end) = (start.unwrap_or_default(), end.unwrap_or(Timestamp::MAX));
 
-	let weight_consumptions: Vec<WeightConsumption> = get_consumption(para)
+	// By default query the consumption that was collected from rpc index 0.
+	let weight_consumptions: Vec<WeightConsumption> = get_consumption(para, 0)
 		.map_err(|_| Error::ConsumptionDataNotFound)?
 		.into_iter()
 		.filter(|consumption| consumption.timestamp >= start && consumption.timestamp <= end)

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -23,7 +23,7 @@
 
 use rocket::{http::Status, response::Responder, Request, Response};
 use serde::{Deserialize, Serialize};
-use shared::payment::PaymentError;
+use shared::{chaindata::ChainDataError, payment::PaymentError};
 
 const LOG_TARGET: &str = "server";
 
@@ -42,6 +42,8 @@ pub enum Error {
 	InvalidData,
 	/// The caller tried to register a parachain without payment.
 	PaymentRequired,
+	// An error occured when trying to read parachain's chaindata.
+	ChainDataError(ChainDataError),
 	/// An error occured when trying to validate the payment.
 	PaymentValidationError(PaymentError),
 }
@@ -64,6 +66,12 @@ impl From<String> for Error {
 			"ConsumptionDataNotFound" => Self::ConsumptionDataNotFound,
 			"InvalidData" => Self::InvalidData,
 			"PaymentRequired" => Self::PaymentRequired,
+			_ if v.starts_with("ChainDataError(") => {
+				let chaindata_error =
+					v.trim_start_matches("ChainDataError(").trim_end_matches(')').trim();
+
+				Error::ChainDataError(ChainDataError::from(chaindata_error.to_string()))
+			},
 			_ if v.starts_with("PaymentValidationError(") => {
 				let payment_error =
 					v.trim_start_matches("PaymentValidationError(").trim_end_matches(')').trim();

--- a/routes/src/register.rs
+++ b/routes/src/register.rs
@@ -54,8 +54,7 @@ pub async fn register_para(registration_data: Json<RegistrationData>) -> Result<
 		return Err(Error::AlreadyRegistered);
 	}
 
-	// TODO: don't unwrap
-	let mut para = chaindata::get_para(relay_chain, para_id).unwrap();
+	let mut para = chaindata::get_para(relay_chain, para_id).map_err(Error::ChainDataError)?;
 
 	if let Some(payment_info) = config().payment_info {
 		let payment_block_number =

--- a/routes/src/register.rs
+++ b/routes/src/register.rs
@@ -28,7 +28,7 @@ use types::Parachain;
 #[serde(crate = "rocket::serde")]
 pub struct RegistrationData {
 	/// The parachain getting registered.
-	pub para: Parachain,
+	pub para: (RelayChain, ParaId),
 	/// The block in which the payment occurred for the specific parachain.
 	///
 	/// In free mode (where payment is not required), this is ignored and can be `None`.

--- a/routes/tests/consumption.rs
+++ b/routes/tests/consumption.rs
@@ -19,11 +19,11 @@ use rocket::{
 	routes,
 };
 use routes::{consumption::consumption, Error};
-use shared::{registry::update_registry, reset_mock_environment};
+use shared::{chaindata::get_para, registry::update_registry, reset_mock_environment};
 use types::{RelayChain::*, WeightConsumption};
 
 mod mock;
-use mock::{mock_consumption, mock_para, MockEnvironment};
+use mock::{mock_consumption, MockEnvironment};
 
 #[test]
 fn getting_all_consumption_data_works() {
@@ -31,7 +31,7 @@ fn getting_all_consumption_data_works() {
 		let rocket = rocket::build().mount("/", routes![consumption]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let response = client.get("/consumption/polkadot/2000").dispatch();
 		assert_eq!(response.status(), Status::Ok);
 
@@ -63,7 +63,7 @@ fn consumption_data_not_found_handled() {
 	let client = Client::tracked(rocket).expect("valid rocket instance");
 
 	// Register a parachain without storing any consumption data.
-	assert!(update_registry(vec![mock_para(Polkadot, 2000)]).is_ok());
+	assert!(update_registry(vec![get_para(Polkadot, 2000).unwrap()]).is_ok());
 
 	let response = client.get("/consumption/polkadot/2000").dispatch();
 	assert_eq!(response.status(), Status::InternalServerError);
@@ -80,7 +80,7 @@ fn pagination_works() {
 		let rocket = rocket::build().mount("/", routes![consumption]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let mock_data = mock_consumption().get(&para).unwrap().clone();
 
 		// CASE 1: Limit response size by setting page size
@@ -125,7 +125,7 @@ fn timestamp_based_filtering_works() {
 		let rocket = rocket::build().mount("/", routes![consumption]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let mock_data = mock_consumption().get(&para).unwrap().clone();
 
 		// CASE 1: setting the starting timestamp filters out the data.
@@ -183,7 +183,7 @@ fn pagination_and_timestamp_filtering_works() {
 		let rocket = rocket::build().mount("/", routes![consumption]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let mock_data = mock_consumption().get(&para).unwrap().clone();
 
 		// Combined Case: Filter by timestamp and paginate

--- a/routes/tests/extend_subscription.rs
+++ b/routes/tests/extend_subscription.rs
@@ -63,7 +63,6 @@ fn cannot_extend_subscription_for_unregistered() {
 		let rocket = rocket::build().mount("/", routes![extend_subscription]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = get_para(Polkadot, 2006).unwrap();
 		let extend_subscription = ExtendSubscriptionData {
 			para: (Polkadot, 2006),
 			payment_block_number: PARA_2000_PAYMENT,

--- a/routes/tests/extend_subscription.rs
+++ b/routes/tests/extend_subscription.rs
@@ -23,11 +23,11 @@ use routes::{
 	extend_subscription::{extend_subscription, ExtendSubscriptionData},
 	Error,
 };
-use shared::{payment::PaymentError, registry::registered_para};
+use shared::{chaindata::get_para, payment::PaymentError, registry::registered_para};
 use types::RelayChain::*;
 
 mod mock;
-use mock::{mock_para, MockEnvironment};
+use mock::MockEnvironment;
 
 const PARA_2000_PAYMENT: BlockNumber = 8624975;
 
@@ -37,7 +37,7 @@ fn extend_subscription_works() {
 		let rocket = rocket::build().mount("/", routes![extend_subscription]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let extend_subscription = ExtendSubscriptionData {
 			para: (para.relay_chain.clone(), para.para_id),
 			payment_block_number: PARA_2000_PAYMENT,
@@ -63,9 +63,9 @@ fn cannot_extend_subscription_for_unregistered() {
 		let rocket = rocket::build().mount("/", routes![extend_subscription]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2001);
+		let para = get_para(Polkadot, 2006).unwrap();
 		let extend_subscription = ExtendSubscriptionData {
-			para: (para.relay_chain.clone(), para.para_id),
+			para: (Polkadot, 2006),
 			payment_block_number: PARA_2000_PAYMENT,
 		};
 
@@ -85,7 +85,7 @@ fn providing_non_finalized_payment_block_number_fails() {
 		let rocket = rocket::build().mount("/", routes![extend_subscription]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2000);
+		let para = get_para(Polkadot, 2000).unwrap();
 		let extend_subscription = ExtendSubscriptionData {
 			para: (para.relay_chain.clone(), para.para_id),
 			payment_block_number: 99999999,
@@ -110,8 +110,8 @@ fn payment_not_found_works() {
 		let rocket = rocket::build().mount("/", routes![extend_subscription]);
 		let client = Client::tracked(rocket).expect("valid rocket instance");
 
-		let para = mock_para(Polkadot, 2005);
-		// We are extending the subscription for para 2005, but the payment is for para 2000.
+		let para = get_para(Polkadot, 2004).unwrap();
+		// We are extending the subscription for para 2004, but the payment is for para 2000.
 		let extend_subscription = ExtendSubscriptionData {
 			para: (para.relay_chain.clone(), para.para_id),
 			payment_block_number: PARA_2000_PAYMENT,

--- a/routes/tests/mock.rs
+++ b/routes/tests/mock.rs
@@ -16,9 +16,12 @@
 #[cfg(test)]
 use maplit::hashmap;
 use scopeguard::guard;
-use shared::{consumption::write_consumption, registry::update_registry, reset_mock_environment};
+use shared::{
+	chaindata::get_para, consumption::write_consumption, registry::update_registry,
+	reset_mock_environment,
+};
 use std::collections::HashMap;
-use types::{ParaId, Parachain, RelayChain, RelayChain::*, WeightConsumption};
+use types::{Parachain, RelayChain::*, WeightConsumption};
 
 #[derive(Default)]
 pub struct MockEnvironment {
@@ -57,7 +60,7 @@ impl MockEnvironment {
 
 pub fn mock_consumption() -> HashMap<Parachain, Vec<WeightConsumption>> {
 	hashmap! {
-		mock_para(Polkadot, 2000) => vec![
+		get_para(Polkadot, 2000).unwrap() => vec![
 			WeightConsumption {
 				block_number: 1,
 				timestamp: 0,
@@ -83,7 +86,7 @@ pub fn mock_consumption() -> HashMap<Parachain, Vec<WeightConsumption>> {
 				proof_size: (0.2, 0.1, 0.3).into(),
 			},
 		],
-		mock_para(Polkadot, 2005) => vec![
+		get_para(Polkadot, 2004).unwrap() => vec![
 			WeightConsumption {
 				block_number: 1,
 				timestamp: 0,
@@ -91,15 +94,5 @@ pub fn mock_consumption() -> HashMap<Parachain, Vec<WeightConsumption>> {
 				proof_size: (0.6, 0.2, 0.1).into(),
 			},
 		],
-	}
-}
-
-pub fn mock_para(relay: RelayChain, para_id: ParaId) -> Parachain {
-	Parachain {
-		name: format!("{}-{}", relay, para_id),
-		rpc_url: format!("wss://{}-{}.com", relay, para_id),
-		para_id,
-		relay_chain: relay,
-		last_payment_timestamp: 0,
 	}
 }

--- a/routes/tests/mock.rs
+++ b/routes/tests/mock.rs
@@ -38,7 +38,7 @@ impl MockEnvironment {
 
 		for (para, weight_consumptions) in &mock.weight_consumptions {
 			weight_consumptions.iter().for_each(|consumption| {
-				write_consumption(para.clone(), consumption.clone())
+				write_consumption(para.clone(), consumption.clone(), 0)
 					.expect("Failed to write conusumption data");
 			});
 		}

--- a/routes/tests/registry.rs
+++ b/routes/tests/registry.rs
@@ -19,10 +19,11 @@ use rocket::{
 	routes,
 };
 use routes::registry::registry;
+use shared::chaindata::get_para;
 use types::{Parachain, RelayChain::*};
 
 mod mock;
-use mock::{mock_para, MockEnvironment};
+use mock::MockEnvironment;
 
 #[test]
 fn getting_registry_works() {
@@ -36,7 +37,10 @@ fn getting_registry_works() {
 		let mut registry = parse_ok_response(response);
 		registry.sort_by_key(|p| p.para_id);
 
-		assert_eq!(registry, vec![mock_para(Polkadot, 2000), mock_para(Polkadot, 2005)]);
+		assert_eq!(
+			registry,
+			vec![get_para(Polkadot, 2000).unwrap(), get_para(Polkadot, 2004).unwrap()]
+		);
 	});
 }
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TRACKER_LOGS="logs/tracker-logs.out"
+WATCHDOG_LOGS="logs/watchdog-logs.out"
+TRACKER="./target/release/tracker"
+
+reset_env() {
+    PIDS=$(pgrep -f "$TRACKER")
+
+    if [ -z "$PIDS" ]; then
+        echo "Process not found."
+    else
+        # Kill each process
+        for PID in $PIDS; do
+            kill -9 $PID
+        done
+    fi
+}
+
+reset_env
+
+# start the tracker again
+nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' > $TRACKER_LOGS 2>&1 &
+# start the watchdog
+nohup sh -c 'scripts/watchdog.sh' > $WATCHDOG_LOGS 2>&1 &

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-TRACKER_LOGS="logs/tracker-logs.out"
-WATCHDOG_LOGS="logs/watchdog-logs.out"
+TRACKER_LOGS_0="logs/tracker-logs-0.out"
+TRACKER_LOGS_1="logs/tracker-logs-1.out"
+
+WATCHDOG_LOGS_0="logs/watchdog-logs-0.out"
+WATCHDOG_LOGS_1="logs/watchdog-logs-1.out"
+
 TRACKER="./target/release/tracker"
+WATCHDOG="scripts/watchdog.sh"
 
 reset_env() {
-    PIDS=$(pgrep -f "$TRACKER")
+    PIDS=$(pgrep -f "$TRACKER|$WATCHDOG")
 
     if [ -z "$PIDS" ]; then
         echo "Process not found."
@@ -20,6 +25,8 @@ reset_env() {
 reset_env
 
 # start the tracker again
-nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' > $TRACKER_LOGS 2>&1 &
+nohup sh -c 'RUST_LOG=INFO ./target/release/tracker --rpc-index 0' > $TRACKER_LOGS_0 2>&1 &
+nohup sh -c 'RUST_LOG=INFO ./target/release/tracker --rpc-index 1' > $TRACKER_LOGS_1 2>&1 &
 # start the watchdog
-nohup sh -c 'scripts/watchdog.sh' > $WATCHDOG_LOGS 2>&1 &
+nohup sh -c 'scripts/watchdog.sh "$1"' _ 0 > $WATCHDOG_LOGS_0 2>&1 &
+nohup sh -c 'scripts/watchdog.sh "$1"' _ 1 > $WATCHDOG_LOGS_1 2>&1 &

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,25 +1,8 @@
 #!/bin/bash
 
-FILE_TO_WATCH="logs/tracker-logs.out"
+FILE_TO_WATCH="logs/tracker-logs-$1.out"
 
 WS_CONNECTION_ERROR="Failed to read message: Networking or low-level protocol error: WebSocket connection error: connection closed"
-TRACKER="./target/release/tracker"
-
-restart_tracker() {
-    PIDS=$(pgrep -f "$TRACKER")
-
-    if [ -z "$PIDS" ]; then
-        echo "Process not found."
-    else
-        # Kill each process
-        for PID in $PIDS; do
-            kill -9 $PID
-        done
-
-        # start the tracker again
-        nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' > $FILE_TO_WATCH 2>&1 &
-    fi
-}
 
 # Continuously watch the file
 tail -f "$FILE_TO_WATCH" | while read LINE
@@ -27,6 +10,6 @@ do
     echo "$LINE" | grep "$WS_CONNECTION_ERROR" > /dev/null
     if [ $? = 0 ]
     then
-       restart_tracker 
+        ./scripts/init.sh
     fi
 done

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FILE_TO_WATCH="nohup.out"
+FILE_TO_WATCH="logs/tracker-logs.out"
 
 WS_CONNECTION_ERROR="Failed to read message: Networking or low-level protocol error: WebSocket connection error: connection closed"
 TRACKER="./target/release/tracker"
@@ -17,7 +17,7 @@ restart_tracker() {
         done
 
         # start the tracker again
-        nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' &
+        nohup sh -c 'RUST_LOG=INFO ./target/release/tracker' > $FILE_TO_WATCH 2>&1 &
     fi
 }
 

--- a/shared/src/chaindata.rs
+++ b/shared/src/chaindata.rs
@@ -36,14 +36,22 @@ struct ChainData {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub enum ChaindataError {
+pub enum ChainDataError {
 	ParaNotFound,
-	RpcIndexOutOfBound,
+}
+
+impl From<String> for ChainDataError {
+	fn from(v: String) -> Self {
+		match v.as_str() {
+			"ParaNotFound" => Self::ParaNotFound,
+			_ => panic!("UnknownError"),
+		}
+	}
 }
 
 /// Get the rpcs of a parachain.
-pub fn get_para(relay: RelayChain, para_id: ParaId) -> Result<Parachain, ChaindataError> {
-	let mut file = File::open(config().chaindata).expect("Chaindata not found");
+pub fn get_para(relay: RelayChain, para_id: ParaId) -> Result<Parachain, ChainDataError> {
+	let mut file = File::open(config().chaindata).expect("ChainData not found");
 	let mut content = String::new();
 
 	file.read_to_string(&mut content).expect("Failed to load chaindata");
@@ -52,7 +60,7 @@ pub fn get_para(relay: RelayChain, para_id: ParaId) -> Result<Parachain, Chainda
 	let index = chaindata
 		.iter()
 		.position(|para| para.para_id == para_id && para.relay == Relay { id: relay.clone() })
-		.ok_or(ChaindataError::ParaNotFound)?;
+		.ok_or(ChainDataError::ParaNotFound)?;
 
 	let para_chaindata = chaindata.get(index).expect("We just found the index; qed");
 

--- a/shared/src/chaindata.rs
+++ b/shared/src/chaindata.rs
@@ -1,0 +1,69 @@
+// This file is part of RegionX.
+//
+// RegionX is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// RegionX is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
+use crate::config::config;
+use serde::{Deserialize, Serialize};
+use std::{fs::File, io::Read};
+use types::{ParaId, RelayChain};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Relay {
+	id: RelayChain,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Rpc {
+	url: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+struct ChainData {
+	pub name: String,
+	pub para_id: ParaId,
+	pub relay: Relay,
+	pub rpcs: Vec<Rpc>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum ChaindataError {
+	ParaNotFound,
+	RpcIndexOutOfBound,
+}
+
+/// Get the rpcs of a parachain.
+pub fn get_para_rpc(
+	relay: RelayChain,
+	para_id: ParaId,
+	rpc_index: u8,
+) -> Result<String, ChaindataError> {
+	let mut file = File::open(config().chaindata).expect("Chaindata not found");
+	let mut content = String::new();
+
+	file.read_to_string(&mut content).expect("Failed to load chaindata");
+	let chaindata: Vec<ChainData> = serde_json::from_str(&content).expect("Failed to serialize");
+
+	let index = chaindata
+		.iter()
+		.position(|para| para.para_id == para_id && para.relay == Relay { id: relay.clone() })
+		.ok_or(ChaindataError::ParaNotFound)?;
+
+	let rpc = chaindata
+		.get(index)
+		.expect("We just found the index; qed")
+		.rpcs
+		.get(rpc_index as usize)
+		.ok_or(ChaindataError::RpcIndexOutOfBound)?;
+
+	Ok(rpc.url.clone())
+}

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -36,6 +36,7 @@ pub struct PaymentInfo {
 pub struct Config {
 	pub output_directory: String,
 	pub registry: String,
+	pub chaindata: String,
 	pub payment_info: Option<PaymentInfo>,
 }
 

--- a/shared/src/config.rs
+++ b/shared/src/config.rs
@@ -44,3 +44,7 @@ pub fn config() -> Config {
 	let config_str = std::fs::read_to_string(CONFIG_FILE).expect("Failed to read config file");
 	toml::from_str(&config_str).expect("Failed to parse config file")
 }
+
+pub fn output_directory(rpc_index: usize) -> String {
+	format!("{}-{}", config().output_directory, rpc_index)
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -23,7 +23,7 @@ pub mod payment;
 pub mod registry;
 
 #[cfg(feature = "test-utils")]
-use crate::config::config;
+use crate::config::output_directory;
 
 const LOG_TARGET: &str = "shared";
 
@@ -43,17 +43,14 @@ pub fn current_timestamp() -> Timestamp {
 // There isn't a good reason to use this other than for testing.
 #[cfg(feature = "test-utils")]
 pub fn reset_mock_environment() {
-	let config = config();
-
 	// Reset the registered paras file:
 	let _registry = registry::init_registry();
 
+	let output_path = output_directory(0);
 	// Remove the output files:
-	let _ = std::fs::create_dir(config.output_directory.clone());
+	let _ = std::fs::create_dir(output_path.clone());
 
-	for entry in
-		std::fs::read_dir(config.output_directory).expect("Failed to read output directory")
-	{
+	for entry in std::fs::read_dir(output_path).expect("Failed to read output directory") {
 		let entry = entry.expect("Failed to ready entry");
 		let path = entry.path();
 		if path.is_file() {

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -16,11 +16,13 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 use types::Timestamp;
 
+pub mod chaindata;
 pub mod config;
 pub mod consumption;
 pub mod payment;
 pub mod registry;
 
+#[cfg(feature = "test-utils")]
 use crate::config::config;
 
 const LOG_TARGET: &str = "shared";

--- a/shared/src/registry.rs
+++ b/shared/src/registry.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use types::{ParaId, Parachain, RelayChain};
 
-pub fn registered_paras(rpc_index: u8) -> Vec<Parachain> {
+pub fn registered_paras() -> Vec<Parachain> {
 	let mut registry = get_registry();
 	let mut content = String::new();
 
@@ -31,12 +31,8 @@ pub fn registered_paras(rpc_index: u8) -> Vec<Parachain> {
 	paras
 }
 
-pub fn registered_para(
-	relay_chain: RelayChain,
-	para_id: ParaId,
-	rpc_index: u8,
-) -> Option<Parachain> {
-	registered_paras(rpc_index)
+pub fn registered_para(relay_chain: RelayChain, para_id: ParaId) -> Option<Parachain> {
+	registered_paras()
 		.iter()
 		.find(|para| para.relay_chain == relay_chain && para.para_id == para_id)
 		.cloned()

--- a/shared/src/registry.rs
+++ b/shared/src/registry.rs
@@ -55,7 +55,7 @@ pub fn update_registry(paras: Vec<Parachain>) -> Result<(), String> {
 }
 
 fn get_registry() -> File {
-	match OpenOptions::new().read(true).write(true).create(true).open(config().registry) {
+	match OpenOptions::new().read(true).write(true).open(config().registry) {
 		Ok(file) => file,
 		Err(_) => init_registry(),
 	}

--- a/shared/src/registry.rs
+++ b/shared/src/registry.rs
@@ -20,19 +20,23 @@ use std::{
 };
 use types::{ParaId, Parachain, RelayChain};
 
-pub fn registered_paras() -> Vec<Parachain> {
+pub fn registered_paras(rpc_index: u8) -> Vec<Parachain> {
 	let mut registry = get_registry();
 	let mut content = String::new();
 
-	// If this fails it simply means that the registered parachains is still empty.
+	// If this fails it simply means that the registry is empty.
 	let _ = registry.read_to_string(&mut content);
 	let paras: Vec<Parachain> = serde_json::from_str(&content).expect("Failed to serialize");
 
 	paras
 }
 
-pub fn registered_para(relay_chain: RelayChain, para_id: ParaId) -> Option<Parachain> {
-	registered_paras()
+pub fn registered_para(
+	relay_chain: RelayChain,
+	para_id: ParaId,
+	rpc_index: u8,
+) -> Option<Parachain> {
+	registered_paras(rpc_index)
 		.iter()
 		.find(|para| para.relay_chain == relay_chain && para.para_id == para_id)
 		.cloned()

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -71,9 +71,7 @@ pub struct Parachain {
 	/// Name of the parachain.
 	pub name: String,
 	/// The rpc url endpoint from where we can query the weight consumption.
-	//
-	// TODO: instead of having only one rpc url specified there should be a fallback.
-	pub rpc_url: String,
+	pub rpcs: Vec<String>,
 	/// The `ParaId` of the parachain.
 	pub para_id: ParaId,
 	/// The relay chain that the parachain is using for block validation.

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with RegionX.  If not, see <https://www.gnu.org/licenses/>.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 
 /// Timestamp based on the 1 Jan 1970 UNIX base, which is persistent across node restarts and OS
@@ -25,7 +25,7 @@ pub type ParaId = u32;
 
 pub type Balance = u128;
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Hash)]
 #[serde(crate = "rocket::serde")]
 pub enum RelayChain {
 	Polkadot,
@@ -47,6 +47,20 @@ impl From<&str> for RelayChain {
 			"polkadot" => RelayChain::Polkadot,
 			"kusama" => RelayChain::Kusama,
 			_ => panic!("Invalid relay chain: {}", s),
+		}
+	}
+}
+
+impl<'de> Deserialize<'de> for RelayChain {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let s = String::deserialize(deserializer)?.to_lowercase();
+		match s.as_str() {
+			"polkadot" | "Polkadot" => Ok(RelayChain::Polkadot),
+			"kusama" | "Kusama" => Ok(RelayChain::Kusama),
+			_ => Err(serde::de::Error::custom(format!("Invalid relay chain: {}", s))),
 		}
 	}
 }


### PR DESCRIPTION
With this PR the registration process is changed such that the RPC endpoint is not provided by the user, but instead is stored locally in the `chaindata.json`. This is necessary since otherwise a user could register a chain and provide an incorrect RPC endpoint(or an endpoint to another chain), resulting in incorrect data.

This PR also introduces a new CLI flag that specifies which RPC endpoint from the chaindata file.